### PR TITLE
Fix for error on calling start_live_video

### DIFF
--- a/instrumental/drivers/cameras/uc480.py
+++ b/instrumental/drivers/cameras/uc480.py
@@ -686,9 +686,15 @@ class UC480_Camera(Camera):
 
     @check_units(framerate='?Hz')
     def start_live_video(self, framerate=None, **kwds):
+        # Changed to be like start_capture 
+        # Otherwise, errors are thrown when running this function
         self._handle_kwds(kwds, fill_coords=False)
         self._set_binning(kwds['vbin'], kwds['hbin'])
         self._set_subsampling(kwds['vsub'], kwds['hsub'])
+        self._refresh_sizes()
+        
+        # Same as above
+        self._handle_kwds(kwds, fill_coords=True)
         self._set_AOI(kwds['left'], kwds['top'], kwds['right'], kwds['bot'])
         self._set_exposure(kwds['exposure_time'])
         self._set_gain(kwds['gain'])


### PR DESCRIPTION
Hi! We found a little error with keywords not being processed correctly in start_live_video. I think that this fixes it, as we are able to acquire frames that way. Thanks a lot for your work! :) Cheers from Ivan at QUANTOP in Niels Bohr Institute, Copenhagen.