### PR TITLE
Correct GW INSTEK GPD-3303S driver information

### DIFF
--- a/instrumental/driver_info.py
+++ b/instrumental/driver_info.py
@@ -106,7 +106,7 @@ driver_info = OrderedDict([
         'params': ['visa_address'],
         'classes': ['GPD_3303S'],
         'imports': [],
-        'visa_info': {'GW Instek': ('GPD-3303S', ['GPD_3303S'])}
+        'visa_info': {'GPD_3303S': ('GW INSTEK', ['GPD-3303S'])}
     }),
     ('scopes.tektronix', {
         'params': ['visa_address'],


### PR DESCRIPTION
If I run the following script:
```
import visa
from instrumental import drivers
rm = visa.ResourceManager()
visa_address='ASRL/dev/ttyUSB1::INSTR'
visa_inst = rm.open_resource(visa_address, open_timeout=50, timeout=200)
print(drivers.get_idn(visa_inst))
```

I get the following answer:
`('GW INSTEK', 'GPD-3303S')`

Thus I propose the following modification to be able to use my GPD-3303S with the library.