### PR TITLE
Fixed driver info for two instrumenst

### DIFF
--- a/instrumental/driver_info.py
+++ b/instrumental/driver_info.py
@@ -1,4 +1,4 @@
-# Auto-generated 2019-04-26T09:00:20.312499
+# Auto-generated 2019-04-26T09:38:10.166813
 from collections import OrderedDict
 
 driver_info = OrderedDict([
@@ -49,10 +49,12 @@ driver_info = OrderedDict([
         },
     }),
     ('laserdiodecontrollers.ilx_lightwave', {
-        'params': ['visa_address'],
-        'classes': [],
+        'params': [],
+        'classes': ['LDC3724B'],
         'imports': [],
-        'visa_info': {},
+        'visa_info': {
+            'LDC3724B': ('ILX Lightwave', ['3724B']),
+        }
     }),
     ('lockins.sr844', {
         'params': ['visa_address'],

--- a/instrumental/driver_info.py
+++ b/instrumental/driver_info.py
@@ -1,4 +1,4 @@
-# Auto-generated 2019-04-26T09:38:10.166813
+# Auto-generated 2019-05-06T16:23:11.970004
 from collections import OrderedDict
 
 driver_info = OrderedDict([
@@ -49,12 +49,12 @@ driver_info = OrderedDict([
         },
     }),
     ('laserdiodecontrollers.ilx_lightwave', {
-        'params': [],
+        'params': ['visa_address'],
         'classes': ['LDC3724B'],
         'imports': [],
         'visa_info': {
             'LDC3724B': ('ILX Lightwave', ['3724B']),
-        }
+        },
     }),
     ('lockins.sr844', {
         'params': ['visa_address'],

--- a/instrumental/driver_info.py
+++ b/instrumental/driver_info.py
@@ -1,4 +1,4 @@
-# Auto-generated 2019-04-24T15:21:59.914853
+# Auto-generated 2019-04-26T09:00:20.312499
 from collections import OrderedDict
 
 driver_info = OrderedDict([
@@ -27,7 +27,7 @@ driver_info = OrderedDict([
         'classes': ['Agilent33250A', 'AgilentE4400B', 'AgilentMXG'],
         'imports': [],
         'visa_info': {
-            'Agilent33250A': ('Agilent Technologies', ['Agilent33250A']),
+            'Agilent33250A': ('Agilent Technologies', ['33250A']),
             'AgilentE4400B': ('Hewlett-Packard', ['ESG-1000B']),
             'AgilentMXG': ('Agilent Technologies', ['N5181A']),
         },

--- a/instrumental/drivers/funcgenerators/agilent.py
+++ b/instrumental/drivers/funcgenerators/agilent.py
@@ -61,7 +61,7 @@ class AgilentMXG(FunctionGenerator, VisaMixin):
 
 class Agilent33250A(FunctionGenerator, VisaMixin):
     _INST_PARAMS_ = ['visa_address']
-    _INST_VISA_INFO_ = ('Agilent Technologies', ['Agilent33250A'])
+    _INST_VISA_INFO_ = ('Agilent Technologies', ['33250A'])
 
     def _initialize(self):
         self._rsrc.read_termination = '\n'

--- a/instrumental/drivers/laserdiodecontrollers/ilx_lightwave.py
+++ b/instrumental/drivers/laserdiodecontrollers/ilx_lightwave.py
@@ -8,9 +8,8 @@ from .. import VisaMixin, SCPI_Facet
 
 
 class LDC3724B(LaserDiodeController, VisaMixin):
-    _INST_PARAMS = ['visa_address']
-    _INST_VISA_INFO_ = ('Agilent Technologies', ['33250A'])
-    #_INST_VISA_INFO_ = ('ILX Lightwave', ['3724B'])
+    _INST_PARAMS_ = ['visa_address']
+    _INST_VISA_INFO_ = ('ILX Lightwave', ['3724B'])
 
     def _initialize(self):
         self._rsrc.read_termination = '\n'

--- a/instrumental/drivers/laserdiodecontrollers/ilx_lightwave.py
+++ b/instrumental/drivers/laserdiodecontrollers/ilx_lightwave.py
@@ -6,9 +6,11 @@ Driver for ILX Lightwave Lasers
 from . import LaserDiodeController
 from .. import VisaMixin, SCPI_Facet
 
-_INST_PARAMS = ['visa_address']
 
 class LDC3724B(LaserDiodeController, VisaMixin):
+    _INST_PARAMS = ['visa_address']
+    _INST_VISA_INFO_ = ('Agilent Technologies', ['33250A'])
+    #_INST_VISA_INFO_ = ('ILX Lightwave', ['3724B'])
 
     def _initialize(self):
         self._rsrc.read_termination = '\n'


### PR DESCRIPTION
Hi Nate,

I'm slowly working on wrapping my head around all of your wonderful code. I had to increase the timeout in order to get the Agilent function generator's *IDN? query to work.

I also could not find an automatic way to get the python setup.py generate to get the proper listing for the ILX Lightwave driver. Perhaps you can tell me what I'm missing. The current driver_info.py file works, but I had to hand-code the ILX Lightwave bit.