### PR TITLE
self._hcam is undefined, I believe what was intended was self._id

### DIFF
--- a/instrumental/drivers/cameras/uc480.py
+++ b/instrumental/drivers/cameras/uc480.py
@@ -941,7 +941,7 @@ class UC480_Camera(Camera):
         else:
             raise Error("Unrecognized trigger mode {}".format(mode))
 
-        ret = lib.is_SetExternalTrigger(self._hcam, new_mode)
+        ret = lib.is_SetExternalTrigger(self._id, new_mode)
         if ret != lib.SUCCESS:
             raise Error("Failed to set external trigger. Return code 0x{:x}".format(ret))
         else:


### PR DESCRIPTION
I wanted to use external trigger for an application in lab but I kept getting errors about self._hcam not being defined. When I inspected the code I realized that self._hcam was probably a holdover from something else and what was really intended was self._id. I tested this quickly on a camera I have in lab and it seems to work.