### PR TITLE
Add Rigol methods

### DIFF
--- a/instrumental/driver_info.py
+++ b/instrumental/driver_info.py
@@ -1,4 +1,4 @@
-# Auto-generated 2019-05-06T16:23:11.970004
+# Auto-generated 2019-09-19T15:55:57.247343
 from collections import OrderedDict
 
 driver_info = OrderedDict([
@@ -35,9 +35,9 @@ driver_info = OrderedDict([
     ('funcgenerators.rigol', {
         'params': ['visa_address'],
         'classes': [],
-        'imports': [],
+        'imports': ['visa'],
         'visa_info': {
-            'DG800': ('Rigol Technologies', ['DG812']),
+            'DG800': ('Rigol Technologies', ['DG811', 'DG812']),
         },
     }),
     ('funcgenerators.tektronix', {
@@ -131,12 +131,28 @@ driver_info = OrderedDict([
             'GPD_3303S': ('GW INSTEK', ['GPD-3303S']),
         },
     }),
+    ('powersupplies.rigol', {
+        'params': ['visa_address'],
+        'classes': [],
+        'imports': ['pyvisa', 'visa'],
+        'visa_info': {
+            'DP700': ('RIGOL TECHNOLOGIES', ['DP711', 'DP712']),
+        },
+    }),
     ('scopes.agilent', {
         'params': ['visa_address'],
         'classes': ['DSO_1000'],
         'imports': ['pyvisa', 'visa'],
         'visa_info': {
             'DSO_1000': ('Agilent Technologies', ['DSO1024A']),
+        },
+    }),
+    ('scopes.rigol', {
+        'params': ['visa_address'],
+        'classes': [],
+        'imports': ['pyvisa', 'visa'],
+        'visa_info': {
+            'DS1000Z': ('RIGOL TECHNOLOGIES', ['DS1054Z']),
         },
     }),
     ('scopes.tektronix', {

--- a/instrumental/drivers/__init__.py
+++ b/instrumental/drivers/__init__.py
@@ -452,34 +452,40 @@ class VisaMixin(Instrument):
 
         >>> inst.write('source{}:value {}', channel, value)
         """
-        full_message = message.format(*args, **kwds)
+        full_message = fmt = message.format(*args, **kwds)
         if self._in_transaction:
-            if full_message[0] != ':':
-                full_message = ':' + full_message
+            if fmt[0] != ':':
+                full_message = ':' + fmt
             self._message_queue.append(full_message)
         else:
-            self._rsrc.write(full_message)
+            self._rsrc.write(fmt)
 
     def query(self, message, *args, **kwds):
         """Query the instrument's VISA resource with `message`
 
         Flushes the message queue if called within a transaction.
         """
+        full_message = fmt = message.format(*args, **kwds)
         if self._in_transaction:
-            self._flush_message_queue()  # TODO: combine query with this message?
-        return self._rsrc.query(message.format(*args, **kwds))
+            if fmt[0] != ':':
+                full_message = ':' + fmt
+            self._message_queue.append(full_message)
+        else:
+            return self._rsrc.query(fmt)
 
     @contextlib.contextmanager
     def transaction(self):
         """Transaction context manager to auto-chain VISA messages
 
-        Queues individual messages written with the `write()` method and sends them all at once,
-        joined by ';'. Messages are actually sent (1) when a call to `query()` is made and (2)
-        upon the end of transaction.
+        Queues individual messages written with the `write()` and `query()` methods and sends them
+        all at once, joined by ';'. Messages are sent upon the end of the transaction.
 
-        This is especially useful when using higher-level functions that call `write()`, as it lets
-        you combine multiple logical operations into a single message (if only using writes), which
-        can be faster than sending lots of little messages.
+        This is especially useful when using higher-level functions that call `write()` or
+        `query()`, as it lets you combine multiple logical operations into a single message,
+        which can be faster than sending lots of little messages.
+
+        Note that all query() calls need to return a string for the transaction. This is important
+        when using a Facet since it is possible to make a Facet return an object.
 
         Be cognizant that a visa resource's write and query methods are not transaction-aware, only
         VisaMixin's are. If you need to call one of these methods (e.g. write_raw), make sure you
@@ -490,9 +496,10 @@ class VisaMixin(Instrument):
             >>> with myinst.transaction():
             ...     myinst.write('A')
             ...     myinst.write('B')
-            ...     myinst.query('C?')  # Query forces flush. Writes "A;B" and queries "C?"
-            ...     myinst.write('D')
-            ...     myinst.write('E')  # End of transaction block, writes "D;E"
+            ...     myinst.query('C?')
+            ...     myinst.query('D?')
+            ...     myinst.write('E')  # End of transaction block, writes "A;B;C?;D?;E"
+            >>> print(myinst.response) # Shows the responses of "C?" and "D?" as a tuple
         """
         self._start_transaction()
         yield
@@ -502,7 +509,7 @@ class VisaMixin(Instrument):
         self._message_queue = []
 
     def _end_transaction(self):
-        self._flush_message_queue()
+        self.response = self._flush_message_queue()
         self._message_queue = None  # signals end of transaction
 
     def _flush_message_queue(self):
@@ -510,8 +517,12 @@ class VisaMixin(Instrument):
         if not self._in_transaction:
             return
         message = ';'.join(self._message_queue)
-        self._rsrc.write(message)
         self._message_queue = []
+
+        if message.find('?') != -1:
+            return self._rsrc.query(message).split(';')
+        else:
+            self._rsrc.write(message)
 
     @property
     def _in_transaction(self):

--- a/instrumental/drivers/powermeters/newport.py
+++ b/instrumental/drivers/powermeters/newport.py
@@ -186,7 +186,7 @@ class Newport_1830_C(PowerMeter, VisaMixin):
         val = self.write('A?')
         return bool(val)
 
-    def get_valid_power(self, max_attempts=10, polling_interval=0.1*u.s)):
+    def get_valid_power(self, max_attempts=10, polling_interval=0.1*u.s):
         """Returns a valid power reading
 
         This convience function will try to measure a valid power up to a

--- a/instrumental/drivers/powersupplies/rigol.py
+++ b/instrumental/drivers/powersupplies/rigol.py
@@ -10,8 +10,8 @@ from visa import ResourceManager
 import pyvisa
 import re
 
-_INST_PARAMS_ = ['visa_address']
-_INST_VISA_INFO_ = {
+_INST_PARAMS = ['visa_address']
+_INST_VISA_INFO = {
     'DP700': ('RIGOL TECHNOLOGIES', ['DP711', 'DP712']),
 }
 
@@ -53,6 +53,8 @@ class DP700(RigolPowerSupply, VisaMixin):
     current_protection_state = SCPI_Facet('SOURce:CURRent:PROTection:STATe', convert=OnOffState)
     output = SCPI_Facet('OUTPut:STATe', convert=OnOffState)
     beeper = SCPI_Facet('SYSTem:BEEPer', convert=OnOffState)
+    measured_voltage = SCPI_Facet('MEASure:VOLTage', convert=float, readonly=True, units='A')
+    measured_current = SCPI_Facet('MEASure:CURRent', convert=float, readonly=True, units='A')
 
     @property
     def manufacturer(self):
@@ -73,12 +75,6 @@ class DP700(RigolPowerSupply, VisaMixin):
     def version(self):
         _, _, _, version = self.query('*IDN?').rstrip().split(',', 4)
         return version
-
-    def get_measured_voltage(self):
-        return Q_(self.query(':MEASure:VOLTage?'), ureg.volt)
-
-    def get_measured_current(self):
-        return Q_(self.query(':MEASure:CURRent?'), ureg.ampere)
 
     @current_protection_state.setter
     def current_protection_state(self, val):


### PR DESCRIPTION
- Fix a syntax error in powermeters.newport preventing driver_info generation
- Use correct var names so that the driver_info file can parse the other Rigol
  drivers
- Regenerate driver_info.py