### PR TITLE
Changed "/" to "//" for explicit floor division for both Python 2 and 3.

### DIFF
--- a/instrumental/drivers/cameras/__init__.py
+++ b/instrumental/drivers/cameras/__init__.py
@@ -233,12 +233,12 @@ class Camera(Instrument):
             elif kwds[names[3]] is not None:  # Right given
                 kwds[names[2]] = 0
             elif kwds[names[1]] is not None:  # Center given
-                if kwds[names[1]] > max_width/2:
+                if kwds[names[1]] > max_width//2:
                     kwds[names[3]] = max_width  # Bounded by the right
                 else:
                     kwds[names[2]] = 0  # Bounded by the left
             else:  # Width given
-                kwds[names[1]] = max_width/2  # Centered
+                kwds[names[1]] = max_width//2  # Centered
         elif n_args != 2:
             raise ValueError("Only two of {} should be provided".format(names))
 
@@ -253,14 +253,14 @@ class Camera(Instrument):
         if left is not None:
             if right is not None:
                 width = right - left
-                cx = left + width/2
+                cx = left + width//2
             elif cx is not None:
                 # Assume an even width
                 right = cx + (cx - left)
                 width = right - left
             elif width is not None:
                 right = left + width
-                cx = left + width/2
+                cx = left + width//2
         elif right is not None:
             if cx is not None:
                 # Assume an even width
@@ -268,9 +268,9 @@ class Camera(Instrument):
                 left = right - width
             elif width is not None:
                 left = right - width
-                cx = left + width/2
+                cx = left + width//2
         else:
-            left = cx - width/2
+            left = cx - width//2
             right = left + width
 
         kwds.update(zip(names, (width, cx, left, right)))


### PR DESCRIPTION
Fixed a bug (mentioned in PR https://github.com/mabuchilab/Instrumental/pull/105) where indices could end up as floats in Python 3 where `//` is necessary for floor division.