### PR TITLE
Facet validators

### DIFF
--- a/instrumental/driver_info.py
+++ b/instrumental/driver_info.py
@@ -103,6 +103,12 @@ driver_info = OrderedDict([
         'classes': ['NSCA1'],
         'imports': ['visa'],
     }),
+    ('motion.newport', {
+        'params': ['visa_address'],
+        'classes': ['ESP300'],
+        'imports': [],
+        'visa_info': {},
+    }),
     ('motion.tdc_001', {
         'params': ['serial'],
         'classes': ['TDC001'],

--- a/instrumental/drivers/facet.py
+++ b/instrumental/drivers/facet.py
@@ -145,6 +145,14 @@ class Facet(object):
     def __repr__(self):
         return "<Facet '{}'>".format(self.name)
 
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return self.get_value(obj)
+
+    def __set__(self, obj, qty):
+        self.set_value(obj, qty)
+
     def _set_limits(self, limits):
         if limits is not None:
             for limit in limits:
@@ -194,11 +202,6 @@ class Facet(object):
                 value = Q_(value, self.units)
         return value
 
-    def __get__(self, obj, objtype=None):
-        if obj is None:
-            return self
-        return self.get_value(obj)
-
     def get_value(self, obj, use_cache=True):
         if self.fget is None:
             raise AttributeError
@@ -214,9 +217,6 @@ class Facet(object):
 
         log.debug('Facet value was %s', instance.cached_val)
         return instance.cached_val
-
-    def __set__(self, obj, qty):
-        self.set_value(obj, qty)
 
     def convert_user_input(self, value, obj):
         """Validate and convert an input value to its 'external' form"""
@@ -271,21 +271,6 @@ class Facet(object):
 
         instance.cached_val = value
         log.info('Facet value is %s', value)
-
-    def __call__(self, fget):
-        return self.getter(fget)
-
-    def getter(self, fget):
-        self.fget = fget
-        if not self.__doc__:
-            self.__doc__ = fget.__doc__
-        return self
-
-    def setter(self, fset):
-        self.fset = fset
-        if not self.__doc__:
-            self.__doc__ = fset.__doc__
-        return self
 
 
 class AbstractFacet(Facet):

--- a/instrumental/drivers/facet.py
+++ b/instrumental/drivers/facet.py
@@ -199,7 +199,7 @@ class Facet(object):
                     raise ValueError('Facet limits must be raw numbers, strings, or None')
 
         if limits is None:
-            self.limits = (None, None, None)
+            self.limits = None
         elif len(limits) == 1:
             self.validator = validators.strict_range
             self.values = (0, limits[0])
@@ -216,8 +216,10 @@ class Facet(object):
             raise ValueError("`limits` must be a sequence of length 1 to 3")
 
     def _load_limits(self, obj):
-        self.values = tuple((getattr(obj, l) if isinstance(l, basestring) else l)
-                     for l in self.limits)
+        if self.limits is not None:
+            self.values = tuple(
+                (getattr(obj, l) if isinstance(l, basestring) else l)
+                 for l in self.limits)
 
     def instance(self, obj):
         """Get the FacetData associated with `obj`"""
@@ -305,7 +307,7 @@ class Facet(object):
 
         instance = self.instance(obj)
         self._load_limits(obj)
-        value, nice_value = self.conv_set(value)
+        value, nice_value = self.conv_set(value, obj)
 
         if not (self.cacheable and use_cache) or instance.cached_val != nice_value:
             log.info('Setting value of facet %s', self.name)

--- a/instrumental/drivers/facet.py
+++ b/instrumental/drivers/facet.py
@@ -199,7 +199,7 @@ class Facet(object):
                     raise ValueError('Facet limits must be raw numbers, strings, or None')
 
         if limits is None:
-            pass
+            self.limits = (None, None, None)
         elif len(limits) == 1:
             self.validator = validators.strict_range
             self.values = (0, limits[0])
@@ -305,7 +305,7 @@ class Facet(object):
 
         instance = self.instance(obj)
         self._load_limits(obj)
-        value, nice_value = self.convert_user_input(value, obj)
+        value, nice_value = self.conv_set(value, obj)
 
         if not (self.cacheable and use_cache) or instance.cached_val != nice_value:
             log.info('Setting value of facet %s', self.name)

--- a/instrumental/drivers/facet.py
+++ b/instrumental/drivers/facet.py
@@ -305,7 +305,7 @@ class Facet(object):
 
         instance = self.instance(obj)
         self._load_limits(obj)
-        value, nice_value = self.conv_set(value, obj)
+        value, nice_value = self.conv_set(value)
 
         if not (self.cacheable and use_cache) or instance.cached_val != nice_value:
             log.info('Setting value of facet %s', self.name)

--- a/instrumental/drivers/facet.py
+++ b/instrumental/drivers/facet.py
@@ -307,7 +307,7 @@ class Facet(object):
 
         instance = self.instance(obj)
         self._load_limits(obj)
-        value, nice_value = self.conv_set(value, obj)
+        value, nice_value = self.conv_set(value)
 
         if not (self.cacheable and use_cache) or instance.cached_val != nice_value:
             log.info('Setting value of facet %s', self.name)

--- a/instrumental/drivers/motion/newport.py
+++ b/instrumental/drivers/motion/newport.py
@@ -1,0 +1,679 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Martin Cross
+# 
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2020 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+"""
+Driver module for Newport motion controllers. Supports:
+
+* ESP300
+"""
+import numpy
+import re
+from time import sleep
+from enum import Enum
+from . import Motion
+from .. import Facet, MessageFacet, SCPI_Facet, VisaMixin, validators
+from ..util import visa_timeout_context, check_enums
+from ...log import get_logger
+from ... import Q_
+
+log = get_logger(__name__)
+
+_SUBCLASS_IDN_SRCPATTERN = {
+    # 'subclass': 're.search_pattern'
+    'ESP300': 'ESP300'
+}
+
+
+def _check_visa_support(visa_rsrc):
+    with visa_timeout_context(visa_rsrc, 50):
+        # Assume Newport motion controllers use the same '\r' write termination
+        visa_rsrc.write_termination = '\r'
+        try:
+            # Check if/which Newport motion controller we are connected to
+            resp = visa_rsrc.query('*IDN?')
+            for subclass in _SUBCLASS_IDN_SRCPATTERN.keys():
+                if re.search(_SUBCLASS_IDN_SRCPATTERN[subclass], resp) is not None:
+                    visa_rsrc.clear()
+                    return subclass
+        except:
+            pass
+    return None
+
+
+class AxisError(Exception):
+    """ Raised when a particular axis causes an error for
+    the Newport ESP300. """
+
+    MESSAGES = {
+        '00': 'MOTOR TYPE NOT DEFINED',
+        '01': 'PARAMETER OUT OF RANGE',
+        '02': 'AMPLIFIER FAULT DETECTED',
+        '03': 'FOLLOWING ERROR THRESHOLD EXCEEDED',
+        '04': 'POSITIVE HARDWARE LIMIT DETECTED',
+        '05': 'NEGATIVE HARDWARE LIMIT DETECTED',
+        '06': 'POSITIVE SOFTWARE LIMIT DETECTED',
+        '07': 'NEGATIVE SOFTWARE LIMIT DETECTED',
+        '08': 'MOTOR / STAGE NOT CONNECTED',
+        '09': 'FEEDBACK SIGNAL FAULT DETECTED',
+        '10': 'MAXIMUM VELOCITY EXCEEDED',
+        '11': 'MAXIMUM ACCELERATION EXCEEDED',
+        '12': 'Reserved for future use',
+        '13': 'MOTOR NOT ENABLED',
+        '14': 'Reserved for future use',
+        '15': 'MAXIMUM JERK EXCEEDED',
+        '16': 'MAXIMUM DAC OFFSET EXCEEDED',
+        '17': 'ESP CRITICAL SETTINGS ARE PROTECTED',
+        '18': 'ESP STAGE DEVICE ERROR',
+        '19': 'ESP STAGE DATA INVALID',
+        '20': 'HOMING ABORTED',
+        '21': 'MOTOR CURRENT NOT DEFINED',
+        '22': 'UNIDRIVE COMMUNICATIONS ERROR',
+        '23': 'UNIDRIVE NOT DETECTED',
+        '24': 'SPEED OUT OF RANGE',
+        '25': 'INVALID TRAJECTORY MASTER AXIS',
+        '26': 'PARAMETER CHARGE NOT ALLOWED',
+        '27': 'INVALID TRAJECTORY MODE FOR HOMING',
+        '28': 'INVALID ENCODER STEP RATIO',
+        '29': 'DIGITAL I/O INTERLOCK DETECTED',
+        '30': 'COMMAND NOT ALLOWED DURING HOMING',
+        '31': 'COMMAND NOT ALLOWED DUE TO GROUP',
+        '32': 'INVALID TRAJECTORY MODE FOR MOVING'
+    }
+
+    def __init__(self, code):
+        self.axis = str(code)[0]
+        self.error = str(code)[1:]
+        self.message = self.MESSAGES[self.error]
+
+    def __str__(self):
+        return "Newport ESP300 axis %s reported the error: %s" % (
+            self.axis, self.message)
+
+
+class GeneralError(Exception):
+    """ Raised when the Newport ESP300 has a general error.
+    """
+
+    MESSAGES = {
+        '1': 'PCI COMMUNICATION TIME-OUT',
+        '4': 'EMERGENCY SOP ACTIVATED',
+        '6': 'COMMAND DOES NOT EXIST',
+        '7': 'PARAMETER OUT OF RANGE',
+        '8': 'CABLE INTERLOCK ERROR',
+        '9': 'AXIS NUMBER OUT OF RANGE',
+        '13': 'GROUP NUMBER MISSING',
+        '14': 'GROUP NUMBER OUT OF RANGE',
+        '15': 'GROUP NUMBER NOT ASSIGNED',
+        '17': 'GROUP AXIS OUT OF RANGE',
+        '18': 'GROUP AXIS ALREADY ASSIGNED',
+        '19': 'GROUP AXIS DUPLICATED',
+        '16': 'GROUP NUMBER ALREADY ASSIGNED',
+        '20': 'DATA ACQUISITION IS BUSY',
+        '21': 'DATA ACQUISITION SETUP ERROR',
+        '23': 'SERVO CYCLE TICK FAILURE',
+        '25': 'DOWNLOAD IN PROGRESS',
+        '26': 'STORED PROGRAM NOT STARTED',
+        '27': 'COMMAND NOT ALLOWED',
+        '29': 'GROUP PARAMETER MISSING',
+        '30': 'GROUP PARAMETER OUT OF RANGE',
+        '31': 'GROUP MAXIMUM VELOCITY EXCEEDED',
+        '32': 'GROUP MAXIMUM ACCELERATION EXCEEDED',
+        '22': 'DATA ACQUISITION NOT ENABLED',
+        '28': 'STORED PROGRAM FLASH AREA FULL',
+        '33': 'GROUP MAXIMUM DECELERATION EXCEEDED',
+        '35': 'PROGRAM NOT FOUND',
+        '37': 'AXIS NUMBER MISSING',
+        '38': 'COMMAND PARAMETER MISSING',
+        '34': 'GROUP MOVE NOT ALLOWED DURING MOTION',
+        '39': 'PROGRAM LABEL NOT FOUND',
+        '40': 'LAST COMMAND CANNOT BE REPEATED',
+        '41': 'MAX NUMBER OF LABELS PER PROGRAM EXCEEDED'
+    }
+
+    def __init__(self, code):
+        self.error = str(code)
+        self.message = self.MESSAGES[self.error]
+
+    def __str__(self):
+        return "Newport ESP300 reported the error: %s" % (
+            self.message)
+
+
+class Axis(object):
+    """ Represents an axis of the Newport ESP300 Motor Controller.
+
+    Each axis can have independent parameters from the other axes.
+
+    Mapping of commands:
+    --------------------
+    AC  x not implemented (future dev) 
+    AE  x not implemented (future dev) 
+    AF  x not implemented (future dev) 
+    AG  x not implemented (future dev) 
+    AU  x not implemented (future dev) 
+    BA  x not implemented (future dev) 
+    BK  x not implemented (future dev) 
+    BL  x not implemented (future dev) 
+    BM  x not implemented (future dev) 
+    BN  x not implemented (future dev) 
+    BP  x not implemented (future dev)
+    BQ  x not implemented (future dev) 
+    CL  x not implemented (future dev) 
+    CO  x not implemented (future dev) 
+    DB  x not implemented (future dev) 
+    DH  -> home_pos (property)
+    DP  -> target_pos (property)
+    DV  x not implemented (future dev) 
+    FE  x not implemented (future dev) 
+    FP  -> pos_display_res (property)
+    FR  x not implemented (future dev) 
+    GR  x not implemented (future dev) 
+    ID  -> stage_id (property)
+    JH  -> jog_high_speed (property)
+    JK  x not implemented (future dev) 
+    JW  -> jog_low_speed (property)
+    KD  x not implemented (future dev) 
+    KI  x not implemented (future dev) 
+    KP  x not implemented (future dev) 
+    KS  x not implemented (future dev) 
+    MD  -> motion_done (property)
+    MF  -> motor_state (property)
+    MO  -> motor_state (property)
+    MT  ->
+    MV  x not implemented (future dev) 
+    MZ  ->
+    OH  ->
+    OL  ->
+    OM  ->
+    OR  ->
+    PA  ->
+    PR  ->
+    QD  x not implemented (future dev) 
+    QG  x not implemented (future dev) 
+    QI  x not implemented (future dev) 
+    QM  ->
+    QR  x not implemented (future dev) 
+    QS  x not implemented (future dev) 
+    QT  x not implemented (future dev) 
+    QV  x not implemented (future dev)  
+    SH  ->
+    SL  ->
+    SN  ->
+    SR  ->
+    SS  x not implemented (future dev) 
+    ST  ->
+    SU  ->
+    TJ  x not implemented (future dev) 
+    TP  ->
+    TV  ->
+    VA  ->
+    VB  x not implemented (future dev) 
+    VF  x not implemented (future dev) 
+    VU  x not implemented (future dev) 
+    WP  x not implemented (future dev) 
+    WS  x not implemented (future dev) 
+    ZA  x not implemented (future dev) 
+    ZB  x not implemented (future dev) 
+    ZE  x not implemented (future dev) 
+    ZF  x not implemented (future dev) 
+    ZH  x not implemented (future dev) 
+    ZS  x not implemented (future dev) 
+
+    """
+
+    def __init__(self, axis, controller):
+        self.axis = axis
+        self.controller = controller
+
+    # def _AxisFacet(self, msg, convert=None, readonly=False, **kwds):
+    #     """Facet factory that prepends the axis number to SCPI messages
+
+    #     Parameters
+    #     ----------
+    #     msg : str
+    #         Base message used to create SCPI get- and set-messages. For example, if `msg='voltage'`, the
+    #         get-message is `'voltage?'` and the set-message becomes `'voltage {}'`, where `{}` gets
+    #         filled in by the value being set.
+    #     convert : function or callable
+    #         Function that converts both the string returned by querying the instrument and the set-value
+    #         before it is passed to `str.format()`. Usually something like `int` or `float`.
+    #     readonly : bool, optional
+    #         Whether the Facet should be read-only.
+    #     **kwds :
+    #         Any other keywords are passed along to the `Facet` constructor
+    #     """
+    #     get_msg = str(self.axis) + msg + '?'
+    #     set_msg = None if readonly else str(self.axis) + msg + '{}'
+    #     return MessageFacet(get_msg, set_msg, convert=convert, **kwds)
+
+    def write(self, message, *args, **kwargs):
+        """Override of controller write method.
+
+        prepends <axis> to message string
+        """
+        self.controller.write(str(self.axis) + message, *args, **kwargs)
+
+    def query(self, message, *args, **kwargs):
+        """Override of controller query method.
+
+        prepends <axis> to message string
+        """
+        log.debug('Using overridden query')
+        return self.controller.query(str(self.axis) + message, *args, **kwargs)
+
+    motor_state = Facet(
+        name='motor_state',
+        doc="""On/Off state of the motor.
+
+        0 = motor off
+        1 = motor on
+
+        This property can be set.
+
+        """
+    )
+
+    @motor_state.getter
+    def motor_state_fget(obj):
+        return int(obj.query('MO?'))
+
+    @motor_state.setter
+    def motor_state_fset(obj, value):
+        if value == 1:
+            obj.write('MO')
+        elif value == 0:
+            obj.write('MF')
+        else:
+            raise ValueError('Motor state must be 1 (on) or 0 (off)')
+
+    home_pos = SCPI_Facet(
+        'DH',
+        readonly=False,
+        name='home_pos',
+        doc='''Define the home poisition of the axis.
+
+        When set, the current position is assigned a user specified absolute
+        value. Make sure to set home_preset_pos as well if you want the
+        absolute position to be preserced when homing the stage. When queried,
+        returns the current absolute position of the stage.
+
+        ''',
+        validator=validators.strict_range,
+        values=(2e-9, 2e9),
+        type=float
+    )
+
+    target_pos = SCPI_Facet(
+        'DP',
+        readonly=True,
+        name='target_pos',
+        doc='''Reads the target position.
+
+        Typically used to read the target position while the stage is in
+        motion.
+
+        ''',
+        type=float
+    )
+
+    pos_display_res = SCPI_Facet(
+        'FP',
+        readonly=False,
+        name='pos_display_res',
+        doc='''Position display resolution.
+
+        This command is used to set the display resolution of position
+        information. For instance, if nn = 4, the display will show values as
+        low as 0.0001 units. If nn = 7, the display will show values in
+        exponential form. If the user units (refer SN command) are in encoder
+        counts or stepper increments, the position information is displayed in
+        integer form, independent of the value set by this command.
+
+        ''',
+        validator=validators.strict_discrete_set,
+        values=range(8),
+        type=int
+    )
+
+    stage_id = SCPI_Facet(
+        'ID',
+        readonly=True,
+        name='stage_id',
+        doc='''Stage model and serial number.
+
+        This command is used to read Newport ESP compatible positioner (stage)
+        model and serial number.
+
+        Returns:
+        --------
+        stage_id : str, '<model num.>, <serial, num.>'
+
+        '''
+    )
+
+    jog_high_speed = SCPI_Facet(
+        'JH',
+        readonly=False,
+        name='jog_high_speed',
+        doc='''High jog speed of the axis.
+
+        This command is used to set the high speed for jogging an axis. Its
+        execution is immediate, meaning that the value is changed when the
+        command is processed, including when motion is in progress. It can be
+        used as an immediate command or inside a program.
+
+        The allowable value is between 0 and the maximum allowed by the VU
+        command.
+
+        ''',
+        validator=validators.strict_range,
+        values=(0, float('inf')),  # Upper limit should be dynamic!
+        type=float
+    )
+
+    jog_low_speed = SCPI_Facet(
+        'JW',
+        readonly=False,
+        name='jog_low_speed',
+        doc='''Low jog speed of the axis.
+
+        This command is used to set the low speed for jogging an axis. Its
+        execution is immediate, meaning that the value is changed when the
+        command is processed, including when motion is in progress. It can be
+        used as an immediate command or inside a program.
+
+        The allowable value is between 0 and the maximum allowed by the VU
+        command.
+
+        ''',
+        validator=validators.strict_range,
+        values=(0, float('inf')),  # Upper limit should be dynamic!
+        type=float
+    )
+
+    motion_done = SCPI_Facet(
+        'MD',
+        readonly=True,
+        name='motion_done',
+        doc='''Motion done status.
+
+        This command is used to read the motion status for the specified axis
+        n. The MD command can be used to monitor Homing, absolute, and
+        relative displacement move completion status.
+
+        ''',
+        type=int
+    )
+
+    def move_to_hardware_trvl_lim(self, direction='+'):
+        '''Move to the positive of negative hardware limit.
+
+        Parameters
+        ----------
+        direction : str, '+' positive limit, '-' negative limit
+
+        '''
+        self.write('MT' + direction)
+
+    # left_limit = Instrument.control(
+    #     "SL?", "SL%g",
+    #     """ A floating point property that controls the left software
+    #     limit of the axis. """
+    # )
+
+    # right_limit = Instrument.control(
+    #     "SR?", "SR%g",
+    #     """ A floating point property that controls the right software
+    #     limit of the axis. """
+    # )
+
+    # units = Instrument.control(
+    #     "SN?", "SN%d",
+    #     """ A string property that controls the displacement units of the
+    #     axis, which can take values of: enconder count, motor step, millimeter,
+    #     micrometer, inches, milli-inches, micro-inches, degree, gradient, radian,
+    #     milliradian, and microradian.
+    #     """,
+    #     validator=strict_discrete_set,
+    #     values={
+    #         'encoder count':0, 'motor step':1, 'millimeter':2,
+    #         'micrometer':3, 'inches':4, 'milli-inches':5,
+    #         'micro-inches':6, 'degree':7, 'gradient':8,
+    #         'radian':9, 'milliradian':10, 'microradian':11
+    #     },
+    #     map_values=True
+    # )
+
+    # motion_done = Instrument.measurement(
+    #     "MD?",
+    #     """ Returns a boolean that is True if the motion is finished.
+    #     """,
+    #     cast=bool
+    # )
+
+
+
+    # def enable(self):
+    #     """ Enables motion for the axis. """
+    #     self.write("MO")
+
+    # def disable(self):
+    #     """ Disables motion for the axis. """
+    #     self.write("MF")
+
+    # def home(self, type=1):
+    #     """ Drives the axis to the home position, which may be the negative
+    #     hardware limit for some actuators (e.g. LTA-HS).
+    #     type can take integer values from 0 to 6.
+    #     """
+    #     home_type = strict_discrete_set(type, [0,1,2,3,4,5,6])
+    #     self.write("OR%d" % home_type)
+
+    # def define_position(self, position):
+    #     """ Overwrites the value of the current position with the given
+    #     value. """
+    #     self.write("DH%g" % position)
+
+    # def zero(self):
+    #     """ Resets the axis position to be zero at the current poisiton.
+    #     """
+    #     self.write("DH")
+
+    # def wait_for_stop(self, delay=0, interval=0.05):
+    #     """ Blocks the program until the motion is completed. A further
+    #     delay can be specified in seconds.
+    #     """
+    #     self.write("WS%d" % (delay*1e3))
+    #     while not self.motion_done:
+    #         sleep(interval)
+
+
+class ESP300(Motion, VisaMixin):
+    """A Newport ESP300 motion controller.
+
+    Mapping of commands:
+    --------------------
+    AB  ->  
+    AP  x not implemented (future dev) 
+    BG  x not implemented (future dev) 
+    BO  x not implemented (future dev) 
+    DC  x not implemented (future dev) 
+    DD  x not implemented (future dev) 
+    DE  x not implemented (future dev) 
+    DF  x not implemented (future dev) 
+    DG  x not implemented (future dev) 
+    DL  x not implemented (future dev) 
+    DO  x not implemented (future dev) 
+    EO  x not implemented (future dev) 
+    EP  x not implemented (future dev) 
+    ES  x not implemented (future dev) 
+    EX  x not implemented (future dev) 
+    HA  x not implemented (future dev) 
+    HB  x not implemented (future dev) 
+    HC  x not implemented (future dev) 
+    HD  x not implemented (future dev) 
+    HE  x not implemented (future dev) 
+    HF  x not implemented (future dev) 
+    HJ  x not implemented (future dev) 
+    HL  x not implemented (future dev) 
+    HN  x not implemented (future dev) 
+    HO  x not implemented (future dev) 
+    HP  x not implemented (future dev) 
+    HQ  x not implemented (future dev) 
+    HS  x not implemented (future dev) 
+    HV  x not implemented (future dev) 
+    HW  x not implemented (future dev) 
+    HX  x not implemented (future dev) 
+    HZ  x not implemented (future dev) 
+    JL  x not implemented (future dev) 
+    LP  x not implemented (future dev) 
+    PH  ->
+    QP  x not implemented (future dev) 
+    RQ  ->
+    RS  ->
+    SA  ->
+    SB  x not implemented (future dev) 
+    SI  x not implemented (future dev) 
+    SK  x not implemented (future dev) 
+    SM  ->
+    TB  -> error_msg (property)
+    TE  -> error_num (property)
+    TS  -> 
+    TX  ->
+    UF  x not implemented (future dev) 
+    UH  x not implemented (future dev) 
+    UL  x not implemented (future dev) 
+    VE  ->
+    WT  x not implemented (future dev) 
+    XM  x not implemented (future dev) 
+    XX  x not implemented (future dev) 
+    ZU  x not implemented (future dev) 
+    ZZ  x not implemented (future dev) 
+
+    """
+
+    _INST_PARAMS_ = ['visa_address']
+
+    def _initialize(self):
+        self.resource.write_termination = '\r'
+        self.resource.read_termination = '\r\n'
+        self.ax_1 = Axis(1, self)
+
+    def close(self):
+        self._rsrc.control_ren(False)  # Disable remote mode
+
+    # Tell list_instruments how to close this VISA resource properly
+    @staticmethod
+    def _close_resource(resource):
+        resource.control_ren(False)  # Disable remote mode
+
+    error_msg = SCPI_Facet(
+        'TB',
+        readonly=True,
+        doc='''Reads the error code, timestamp, and associated message.''',
+    )
+
+    error_num = SCPI_Facet(
+        'TE',
+        readonly=True,
+        doc='''Reads the error code.''',
+    )
+
+    controller_status = SCPI_Facet(
+        'TS',
+        readonly=True,
+        doc='''Reads the controller status byte.'''
+    )
+
+    # def __init__(self, resourceName, **kwargs):
+    #     super(ESP300, self).__init__(
+    #         resourceName,
+    #         "Newport ESP 300 Motion Controller",
+    #         **kwargs
+    #     )
+    #     # Defines default axes, which can be overwritten
+    #     self.x = Axis(1, self)
+    #     self.y = Axis(2, self)
+    #     self.phi = Axis(3, self)
+
+    # def clear_errors(self):
+    #     """ Clears the error messages by checking until a 0 code is
+    #     recived. """
+    #     while self.error != 0:
+    #         continue
+
+    # @property
+    # def errors(self):
+    #     """ Returns a list of error Exceptions that can be later raised, or
+    #     used to diagnose the situation.
+    #     """
+    #     errors = []
+
+    #     code = self.error
+    #     while code != 0:
+    #         if code > 100:
+    #             errors.append(AxisError(code))
+    #         else:
+    #             errors.append(GeneralError(code))
+    #         code = self.error
+    #     return errors
+
+    # @property
+    # def axes(self):
+    #     """ A list of the :class:`Axis <pymeasure.instruments.newport.esp300.Axis>`
+    #     objects that are present. """
+    #     axes = []
+    #     directory = dir(self)
+    #     for name in directory:
+    #         if name == 'axes':
+    #             continue # Skip this property
+    #         try:
+    #             item = getattr(self, name)
+    #             if isinstance(item, Axis):
+    #                 axes.append(item)
+    #         except TypeError:
+    #             continue
+    #         except Exception as e:
+    #             raise e
+    #     return axes
+
+    # def enable(self):
+    #     """ Enables all of the axes associated with this controller.
+    #     """
+    #     for axis in self.axes:
+    #         axis.enable()
+
+    # def disable(self):
+    #     """ Disables all of the axes associated with this controller.
+    #     """
+    #     for axis in self.axes:
+    #         axis.disable()
+
+    # def shutdown(self):
+    #     """ Shuts down the controller by disabling all of the axes.
+    #     """
+    #     self.disable()
+

--- a/instrumental/drivers/validators.py
+++ b/instrumental/drivers/validators.py
@@ -1,0 +1,182 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2020 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from decimal import Decimal
+
+
+def strict_range(value, values):
+    """ Provides a validator function that returns the value
+    if its value is less than the maximum and greater than the
+    minimum of the range. Otherwise it raises a ValueError.
+    :param value: A value to test
+    :param values: A range of values (range, list, etc.)
+    :raises: ValueError if the value is out of the range
+    """
+    if min(values) <= value <= max(values):
+        return value
+    else:
+        raise ValueError('Value of {:g} is not in range [{:g},{:g}]'.format(
+            value, min(values), max(values)
+        ))
+
+
+def strict_discrete_range(value, values, step):
+    """ Provides a validator function that returns the value
+    if its value is less than the maximum and greater than the
+    minimum of the range and is a multiple of step.
+    Otherwise it raises a ValueError.
+    :param value: A value to test
+    :param values: A range of values (range, list, etc.)
+    :param step: Minimum stepsize (resolution limit)
+    :raises: ValueError if the value is out of the range
+    """
+    # use Decimal type to provide correct decimal compatible floating
+    # point arithmetic compared to binary floating point arithmetic
+    if (strict_range(value, values) == value and
+            Decimal(str(value)) % Decimal(str(step)) == 0):
+        return value
+    else:
+        raise ValueError('Value of {:g} is not a multiple of {:g}'.format(
+            value, step
+        ))
+
+
+def strict_discrete_set(value, values):
+    """ Provides a validator function that returns the value
+    if it is in the discrete set. Otherwise it raises a ValueError.
+    :param value: A value to test
+    :param values: A set of values that are valid
+    :raises: ValueError if the value is not in the set
+    """
+    if value in values:
+        return value
+    else:
+        raise ValueError('Value of {} is not in the discrete set {}'.format(
+            value, values
+        ))
+
+
+def truncated_range(value, values):
+    """ Provides a validator function that returns the value
+    if it is in the range. Otherwise it returns the closest
+    range bound.
+    :param value: A value to test
+    :param values: A set of values that are valid
+    """
+    if min(values) <= value <= max(values):
+        return value
+    elif value > max(values):
+        return max(values)
+    else:
+        return min(values)
+
+
+def discrete_range(value, values, step):
+    """ Provides a validator function that returns the value, rounded to the
+    nearest multiple of step, if its value is less than the maximum and
+    greater than the minimum of the range. Otherwise it raises a ValueError.
+    :param value: A value to test
+    :param values: A range of values (range, list, etc.)
+    :param step: Minimum stepsize (resolution limit)
+    :raises: ValueError if the value is out of the range
+    """
+    # use Decimal type to provide correct decimal compatible floating
+    # point arithmetic compared to binary floating point arithmetic
+    if strict_range(value, values) == value:
+        remainder = Decimal(str(value)) % Decimal(str(step))
+        return value - remainder + round(remainder)*step
+    else:
+        raise ValueError('Value of {:g} is not in range [{:g},{:g}]'.format(
+            value, min(values), max(values)
+        ))
+
+
+def modular_range(value, values):
+    """ Provides a validator function that returns the value
+    if it is in the range. Otherwise it returns the value,
+    modulo the max of the range.
+    :param value: a value to test
+    :param values: A set of values that are valid
+    """
+    return value % max(values)
+
+
+def modular_range_bidirectional(value, values):
+    """ Provides a validator function that returns the value
+    if it is in the range. Otherwise it returns the value,
+    modulo the max of the range. Allows negative values.
+    :param value: a value to test
+    :param values: A set of values that are valid
+    """
+    if value > 0:
+        return value % max(values)
+    else:
+        return -1 * (abs(value) % max(values))
+
+
+def truncated_discrete_set(value, values):
+    """ Provides a validator function that returns the value
+    if it is in the discrete set. Otherwise, it returns the smallest
+    value that is larger than the value.
+    :param value: A value to test
+    :param values: A set of values that are valid
+    """
+    # Force the values to be sorted
+    values = list(values)
+    values.sort()
+    for v in values:
+        if value <= v:
+            return v
+
+    return values[-1]
+
+
+def joined_validators(*validators):
+    """ Join a list of validators together as a single.
+    Expects a list of validator functions and values.
+    :param validators: an iterable of other validators
+    """
+
+    def validate(value, values):
+        for validator, vals in zip(validators, values):
+            try:
+                return validator(value, vals)
+            except (ValueError, TypeError):
+                pass
+        raise ValueError("Value of {} not in chained validator set".format(value))
+
+    return validate
+
+
+def discreteTruncate(number, discreteSet):
+    """ Truncates the number to the closest element in the positive discrete set.
+    Returns False if the number is larger than the maximum value or negative.
+    """
+    if number < 0:
+        return False
+    discreteSet.sort()
+    for item in discreteSet:
+        if number <= item:
+            return item
+    return False

--- a/instrumental/plotting.py
+++ b/instrumental/plotting.py
@@ -15,7 +15,6 @@ from matplotlib.pyplot import *
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider
 from matplotlib.transforms import Bbox
-from matplotlib.cbook import is_string_like
 
 from . import u, Q_
 
@@ -27,19 +26,20 @@ def _get_line_tups(*args):
     # Assume all args are either data or format strings, plt.plot will
     # deal with raising exceptions.
     # A line's arguments consist of [x], y, [fmt]
+    string_like = (str, np.str_)
     lines = []
     while args:
         fmt = ''
         y = Q_(args[0])
         if len(args) > 1:
-            if is_string_like(args[1]):
+            if isinstance(args[1], string_like):
                 fmt = args[1]
                 x = Q_(np.arange(y.shape[0], dtype=float))
                 args = args[2:]
             else:
                 x = y
                 y = Q_(args[1])
-                if len(args) > 2 and is_string_like(args[2]):
+                if len(args) > 2 and isinstance(args[2], string_like):
                     fmt = args[2]
                     args = args[3:]
                 else:


### PR DESCRIPTION
Hi Nate,

I tried to port over the "validator" concept from pymeasure. It seems like a fairly straight forward and extensible way to validate user input. Perhaps even things like check_enums could be rolled into it, but that seems a bit complicated at the moment...

I tried to preserve all the functionality of the previous Facet. I have no experience with unit testing, but it sounds like it would be a good way to test if I have broken anything... Do you have any old unit tests?

While I was implementing validators, I also tried to make the get and set methods/algorithms as close to mirrors of each other as possible. It seemed like it could be easier for newbies to understand the code if getting was almost the inverse of setting -- understand one, and you understand the other for free.

Sorry the pull request is a bit messy... It took me a while to appreciate the complexity of dealing with unitful quantities and caching their values. I also needed to get up to speed with python properties, which is why the getter/setter were deleted then readded :)

It would be great if you could shed some light on the purpose of the FacetData class. Could this data be stored in an instance of Facet instead? Or, maybe, should all the instance variables of Facet be stored in a FacetData instance?

-Martin