### PR TITLE
APT devices must return serial number to pick the right one 

### DIFF
--- a/instrumental/drivers/motion/apt.py
+++ b/instrumental/drivers/motion/apt.py
@@ -128,7 +128,7 @@ class TDC001_APT(APT):
         """ Check if the move is completed.
         """
         rsp = self._ser.read(6)
-        if rsp == bytes([0x64, 0x04, 0x0e, 0x00, self.src | 0x80, self.dst ]):
+        if rsp[:4] == bytes([0x64, 0x04, 0x0e, 0x00, self.src | 0x80, self.dst ])[:4]:
             return True
         else:
             return False
@@ -152,7 +152,7 @@ class TDC001_APT(APT):
         """ Check if the device is homed.
         """
         rsp = self._ser.read(6)
-        if rsp == bytes([0x44, 0x04, 0x01, 0x00, self.src, self.dst]):
+        if rsp[:4] == bytes([0x44, 0x04, 0x01, 0x00, self.src, self.dst])[:4]:
             return True
         else:
             return False

--- a/instrumental/drivers/motion/apt.py
+++ b/instrumental/drivers/motion/apt.py
@@ -11,8 +11,9 @@ from .. import ParamSet
 from ... import Q_, u
 
 
-def list_instruments():
-    return [ParamSet(TDC001_APT, port=p.device) for p in comports() if (p.vid, p.pid) == (0x0403, 0xfaf0)]
+def list_instruments(filter_serial_number=None):
+    return [ParamSet(TDC001_APT, port=p.device, serialnumber=p.serial_number) for p in comports() 
+            if (p.vid, p.pid) == (0x0403, 0xfaf0)]
 
 class APT(Motion):
     """Generic Thorlabs device, controlled via APT commands"""

--- a/instrumental/drivers/motion/apt.py
+++ b/instrumental/drivers/motion/apt.py
@@ -128,7 +128,8 @@ class TDC001_APT(APT):
         """ Check if the move is completed.
         """
         rsp = self._ser.read(6)
-        if rsp[:4] == bytes([0x64, 0x04, 0x0e, 0x00, self.src | 0x80, self.dst ])[:4]:
+        ## The 5th and 6th byte in rsp were returned different from 
+        if rsp == bytes([0x64, 0x04, 0x0e, 0x00, self.dst | 0x80, self.src ]):
             return True
         else:
             return False
@@ -152,7 +153,7 @@ class TDC001_APT(APT):
         """ Check if the device is homed.
         """
         rsp = self._ser.read(6)
-        if rsp[:4] == bytes([0x44, 0x04, 0x01, 0x00, self.src, self.dst])[:4]:
+        if rsp == bytes([0x44, 0x04, 0x01, 0x00, self.dst, self.src]):
             return True
         else:
             return False

--- a/instrumental/drivers/motion/apt.py
+++ b/instrumental/drivers/motion/apt.py
@@ -128,7 +128,8 @@ class TDC001_APT(APT):
         """ Check if the move is completed.
         """
         rsp = self._ser.read(6)
-        if rsp == bytes([0x64, 0x04, 0x0e, 0x00, self.src | 0x80, self.dst ]):
+        ## The 5th and 6th byte in rsp were returned different from 
+        if rsp == bytes([0x64, 0x04, 0x0e, 0x00, self.dst | 0x80, self.src ]):
             return True
         else:
             return False
@@ -152,7 +153,7 @@ class TDC001_APT(APT):
         """ Check if the device is homed.
         """
         rsp = self._ser.read(6)
-        if rsp == bytes([0x44, 0x04, 0x01, 0x00, self.src, self.dst]):
+        if rsp == bytes([0x44, 0x04, 0x01, 0x00, self.dst, self.src]):
             return True
         else:
             return False


### PR DESCRIPTION
As originally referenced in https://github.com/mabuchilab/Instrumental/issues/130, I suggest the ```ParamSet``` for Thorlabs motion controllers TDC001 should contain their serial number to tell these apart.

Also I noticed my controllers do not report correctly the 5th and 6th byte, causing some commands to stall. 

With these two fixes, TDC001s work like charm. 