### PR TITLE
patch fix for python 3.11+

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ have been made by:
 - Zak Vendeiro
 - Luka Skoric
 - Drew Risinger
+- Max Herbold

--- a/instrumental/drivers/util.py
+++ b/instrumental/drivers/util.py
@@ -5,7 +5,10 @@ Helpful utilities for writing drivers.
 """
 import copy
 import contextlib
-from inspect import getargspec
+try:
+    from inspect import getargspec
+except ImportError:
+    from inspect import getfullargspec as getargspec
 import pint
 
 from past.builtins import basestring


### PR DESCRIPTION
The library previously riased ImportError in Python 3.11

```
Traceback (most recent call last):
    from instrumental.drivers.cameras import uc480
  File "C:\Programs\Python\Python311\Lib\site-packages\instrumental\drivers\__init__.py", line 22, in <module>
    from .facet import Facet, ManualFacet, MessageFacet, SCPI_Facet, FacetGroup
  File "C:\Programs\Python\Python311\Lib\site-packages\instrumental\drivers\facet.py", line 13, in <module>
    from .util import to_quantity
  File "C:\Programs\Python\Python311\Lib\site-packages\instrumental\drivers\util.py", line 8, in <module>
    from inspect import getargspec
ImportError: cannot import name 'getargspec' from 'inspect' (C:\Programs\Python\Python311\Lib\inspect.py)
```
`getargspec` no longer exists. `getfullargspec` is a patch for this and should probably be used for compatibility with future versions of python. I didn't do a full investigation into what changed in inspect and why this change was made but this seems like the commonly accepted resolution.