### PR TITLE
python >=3.11 inspect changes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ have been made by:
 - Zak Vendeiro
 - Luka Skoric
 - Drew Risinger
+- Max Herbold

--- a/instrumental/drivers/util.py
+++ b/instrumental/drivers/util.py
@@ -217,7 +217,7 @@ def arg_decorator(checker_factory, dec_pos_args, dec_kw_args):
     """
     def wrap(func):
         """Function that actually wraps the function to be decorated"""
-        arg_names, vargs, kwds, default_vals = getargspec(func)
+        arg_names, vargs, kwds, default_vals, *_ = getargspec(func)
         default_vals = default_vals or ()
         pos_arg_names = {i: name for i, name in enumerate(arg_names)}
 
@@ -278,7 +278,7 @@ def _unit_decorator(in_map, out_map, pos_args, named_args):
                 arg = ret[1:]
             ret_units = to_quantity(arg)
 
-        arg_names, vargs, kwds, defaults = getargspec(func)
+        arg_names, vargs, kwds, defaults, *_ = getargspec(func)
 
         pos_units = []
         for arg in pos_args:

--- a/instrumental/drivers/util.py
+++ b/instrumental/drivers/util.py
@@ -5,7 +5,10 @@ Helpful utilities for writing drivers.
 """
 import copy
 import contextlib
-from inspect import getargspec
+try:
+    from inspect import getargspec
+except ImportError:
+    from inspect import getfullargspec as getargspec
 import pint
 
 from past.builtins import basestring


### PR DESCRIPTION
ignore the extra params in `getfullargspec`. This is backwards compatible to <=3.10