### PR TITLE
 `import visa` -> `import pyvisa as visa`

### DIFF
--- a/docs/driver-dev.rst
+++ b/docs/driver-dev.rst
@@ -218,7 +218,8 @@ Instrumental provides some commonly-used utilities for helping you to write driv
    :noindex:
 .. autofunction:: instrumental.drivers.util.unit_mag
    :noindex:
-.. autofunction:: instrumental.drivers.util.check_enums
+.. autofunction:: instrumental.drivers.util.check_enums
+
    :noindex:
 .. autofunction:: instrumental.drivers.util.as_enum
    :noindex:

--- a/docs/visa-dev-example.rst
+++ b/docs/visa-dev-example.rst
@@ -11,7 +11,7 @@ First, let's open the device and play around with it in an ipython shell using p
 
 .. code-block:: ipython
 
-    In [1]: import visa
+    In [1]: import pyvisa as visa
 
     In [2]: rm = visa.ResourceManager()
 

--- a/docs/visa-dev-example.rst
+++ b/docs/visa-dev-example.rst
@@ -11,9 +11,9 @@ First, let's open the device and play around with it in an ipython shell using p
 
 .. code-block:: ipython
 
-    In [1]: import pyvisa as visa
+    In [1]: import pyvisa
 
-    In [2]: rm = visa.ResourceManager()
+    In [2]: rm = pyvisa.ResourceManager()
 
     In [4]: rm.list_resources()
     Out[4]:
@@ -30,7 +30,7 @@ Which resource is our power meter? Well, like all well-behaved SCPI instruments,
     In [5]: for addr in rm.list_resources():
        ...:     try:
        ...:         print(addr, '-->', rm.open_resource(addr).query('*IDN?').strip())
-       ...:     except visa.VisaIOError:
+       ...:     except pyvisa.VisaIOError:
        ...:         pass
        ...:
 

--- a/instrumental/driver_info.py
+++ b/instrumental/driver_info.py
@@ -193,10 +193,26 @@ driver_info = OrderedDict([
             'AgilentOSA': ('AGILENT', ['86142B']),
         },
     }),
+    ('spectrometers.ando', {
+        'params': ['visa_address'],
+        'classes': [],
+        'imports': ['pyvisa', 'visa'],
+        'visa_info': {
+            'AQ6331': ('ANDO', ['AQ6331']),
+        },
+    }),
     ('spectrometers.bristol', {
         'params': ['port'],
         'classes': ['Bristol_721'],
         'imports': [],
+    }),
+    ('spectrometers.hp', {
+        'params': ['visa_address'],
+        'classes': [],
+        'imports': ['pyvisa'],
+        'visa_info': {
+            'HPOSA': ('HEWLETT-PACKARD', ['70951B']),
+        },
     }),
     ('spectrometers.thorlabs_ccs', {
         'params': ['model', 'serial', 'usb'],

--- a/instrumental/driver_info.py
+++ b/instrumental/driver_info.py
@@ -1,4 +1,4 @@
-# Auto-generated 2023-05-15T12:56:15.046873
+# Auto-generated 2023-10-30T12:52:01.206265
 from collections import OrderedDict
 
 driver_info = OrderedDict([
@@ -63,10 +63,18 @@ driver_info = OrderedDict([
             'LDC3724B': ('ILX Lightwave', ['3724B']),
         },
     }),
+    ('lasers.santec', {
+        'params': ['visa_address'],
+        'classes': ['TSL570'],
+        'imports': ['pyvisa'],
+        'visa_info': {
+            'TSL570': ('SANTEC', ['TSL-570']),
+        },
+    }),
     ('lockins.sr844', {
         'params': ['visa_address'],
         'classes': [],
-        'imports': ['visa'],
+        'imports': ['pyvisa'],
         'visa_info': {
             'SR844': ('Stanford_Research_Systems', ['SR844']),
         },
@@ -74,7 +82,7 @@ driver_info = OrderedDict([
     ('lockins.sr850', {
         'params': ['visa_address'],
         'classes': [],
-        'imports': ['visa'],
+        'imports': ['pyvisa'],
         'visa_info': {
             'SR850': ('Stanford_Research_Systems', ['SR850']),
         },
@@ -117,7 +125,7 @@ driver_info = OrderedDict([
     ('motion.newmark', {
         'params': ['serial'],
         'classes': ['NSCA1'],
-        'imports': ['visa'],
+        'imports': ['pyvisa'],
     }),
     ('motion.tdc_001', {
         'params': ['serial'],
@@ -156,7 +164,7 @@ driver_info = OrderedDict([
     ('scopes.agilent', {
         'params': ['visa_address'],
         'classes': ['DSO_1000'],
-        'imports': ['pyvisa', 'visa'],
+        'imports': ['pyvisa'],
         'visa_info': {
             'DSO_1000': ('Agilent Technologies', ['DSO1024A']),
         },
@@ -164,7 +172,7 @@ driver_info = OrderedDict([
     ('scopes.tektronix', {
         'params': ['visa_address'],
         'classes': ['MSO_DPO_2000', 'MSO_DPO_3000', 'MSO_DPO_4000', 'MSO_DPO_7000', 'TDS_1000', 'TDS_200', 'TDS_2000', 'TDS_3000', 'TDS_7000'],
-        'imports': ['pyvisa', 'visa'],
+        'imports': ['pyvisa'],
         'visa_info': {
             'MSO_DPO_2000': ('TEKTRONIX', ['MSO2012', 'MSO2014', 'MSO2024', 'DPO2012', 'DPO2014', 'DPO2024']),
             'MSO_DPO_3000': ('TEKTRONIX', ['MSO3012', 'DPO3012', 'MSO3014', 'DPO3014', 'MSO3032', 'DPO3032', 'MSO3034', 'DPO3034', 'DPO3052', 'MSO3054', 'DPO3054']),
@@ -175,6 +183,14 @@ driver_info = OrderedDict([
             'TDS_2000': ('TEKTRONIX', ['TDS 2002B', 'TDS 2004B', 'TDS 2012B', 'TDS 2014B', 'TDS 2022B', 'TDS 2024B']),
             'TDS_3000': ('TEKTRONIX', ['TDS 3012', 'TDS 3012B', 'TDS 3012C', 'TDS 3014', 'TDS 3014B', 'TDS 3014C', 'TDS 3032', 'TDS 3032B', 'TDS 3032C', 'TDS 3034', 'TDS 3034B', 'TDS 3034C', 'TDS 3052', 'TDS 3052B', 'TDS 3052C', 'TDS 3054', 'TDS 3054B', 'TDS 3054C']),
             'TDS_7000': ('TEKTRONIX', ['TDS7154', 'TDS7254', 'TDS7404']),
+        },
+    }),
+    ('spectrometers.agilent', {
+        'params': ['visa_address'],
+        'classes': ['AgilentOSA'],
+        'imports': ['pyvisa'],
+        'visa_info': {
+            'AgilentOSA': ('AGILENT', ['86142B']),
         },
     }),
     ('spectrometers.bristol', {

--- a/instrumental/drivers/__init__.py
+++ b/instrumental/drivers/__init__.py
@@ -538,12 +538,12 @@ def open_visa_inst(visa_address, raise_errors=False):
 
     Logs well-known errors, and also suppress them if raise_errors is False.
     """
-    import pyvisa as visa
-    rm = visa.ResourceManager()
+    import pyvisa
+    rm = pyvisa.ResourceManager()
     try:
         log.info("Opening VISA resource '{}'".format(visa_address))
         visa_inst = rm.open_resource(visa_address, open_timeout=50, timeout=200)
-    except visa.VisaIOError as e:
+    except pyvisa.VisaIOError as e:
         # Could not create visa instrument object
         log.info("Skipping this resource due to VisaIOError")
         log.info(e)
@@ -562,9 +562,9 @@ def open_visa_inst(visa_address, raise_errors=False):
 
 
 def gen_visa_instruments():
-    import pyvisa as visa
+    import pyvisa
     prev_addr = 'START'
-    rm = visa.ResourceManager()
+    rm = pyvisa.ResourceManager()
     visa_list = rm.list_resources()
     for addr in visa_list:
         if addr.startswith(prev_addr):
@@ -672,10 +672,10 @@ def list_instruments(server=None, module=None, blacklist=None):
     inst_list = []
     if check_visa:
         try:
-            import pyvisa as visa
+            import pyvisa
             try:
                 inst_list.extend(list_visa_instruments())
-            except visa.VisaIOError:
+            except pyvisa.VisaIOError:
                 pass  # Hide visa errors
         except (ImportError, ConfigError):
             pass  # Ignore if PyVISA not installed or configured
@@ -711,7 +711,7 @@ def _get_visa_instrument(params):
     Returns the VISA instrument corresponding to 'visa_address'. Uses caching
     to avoid multiple network accesses.
     """
-    import pyvisa as visa
+    import pyvisa
 
     if 'visa_address' not in params:
         raise InstrumentTypeError()
@@ -727,11 +727,11 @@ def _get_visa_instrument(params):
                                           addr + "' not found!")
     else:
         try:
-            rm = visa.ResourceManager()
+            rm = pyvisa.ResourceManager()
             visa_inst = rm.open_resource(addr, open_timeout=50, **kwds)
             # Cache the instrument for possible later use
             params['**visa_instrument'] = visa_inst
-        except visa.VisaIOError:
+        except pyvisa.VisaIOError:
             # Cache the fact that the instrument isn't connected
             params['**visa_instrument'] = None
             raise InstrumentNotFoundError("Error: device with address '" +
@@ -790,7 +790,7 @@ def get_idn(inst):
 
     Returns (None, None) if unsuccessful.
     """
-    import pyvisa as visa
+    import pyvisa
     try:
         idn = inst.query("*IDN?")
         log.info("*IDN? gives '{}'".format(idn.strip()))
@@ -798,7 +798,7 @@ def get_idn(inst):
         log.info("UnicodeDecodeError while getting IDN. Probably a non-Visa Serial device")
         log.info(str(e))
         return None, None
-    except visa.VisaIOError as e:
+    except pyvisa.VisaIOError as e:
         log.info("Getting IDN failed due to VisaIOError")
         log.info(str(e))
         return None, None
@@ -882,8 +882,8 @@ def find_matching_drivers(in_params):
 
 
 def find_visa_instrument(params):
-    import pyvisa as visa
-    rm = visa.ResourceManager()
+    import pyvisa
+    rm = pyvisa.ResourceManager()
     visa_address = params['visa_address']
 
     if 'module' in params:

--- a/instrumental/drivers/__init__.py
+++ b/instrumental/drivers/__init__.py
@@ -538,7 +538,7 @@ def open_visa_inst(visa_address, raise_errors=False):
 
     Logs well-known errors, and also suppress them if raise_errors is False.
     """
-    import visa
+    import pyvisa as visa
     rm = visa.ResourceManager()
     try:
         log.info("Opening VISA resource '{}'".format(visa_address))
@@ -562,7 +562,7 @@ def open_visa_inst(visa_address, raise_errors=False):
 
 
 def gen_visa_instruments():
-    import visa
+    import pyvisa as visa
     prev_addr = 'START'
     rm = visa.ResourceManager()
     visa_list = rm.list_resources()
@@ -672,7 +672,7 @@ def list_instruments(server=None, module=None, blacklist=None):
     inst_list = []
     if check_visa:
         try:
-            import visa
+            import pyvisa as visa
             try:
                 inst_list.extend(list_visa_instruments())
             except visa.VisaIOError:
@@ -711,7 +711,7 @@ def _get_visa_instrument(params):
     Returns the VISA instrument corresponding to 'visa_address'. Uses caching
     to avoid multiple network accesses.
     """
-    import visa
+    import pyvisa as visa
 
     if 'visa_address' not in params:
         raise InstrumentTypeError()
@@ -790,7 +790,7 @@ def get_idn(inst):
 
     Returns (None, None) if unsuccessful.
     """
-    import visa
+    import pyvisa as visa
     try:
         idn = inst.query("*IDN?")
         log.info("*IDN? gives '{}'".format(idn.strip()))
@@ -882,7 +882,7 @@ def find_matching_drivers(in_params):
 
 
 def find_visa_instrument(params):
-    import visa
+    import pyvisa as visa
     rm = visa.ResourceManager()
     visa_address = params['visa_address']
 

--- a/instrumental/drivers/lasers/femto_ferb.py
+++ b/instrumental/drivers/lasers/femto_ferb.py
@@ -8,7 +8,7 @@ other things make the usb connection appear as a serial port, must be
 installed (available from http://www.toptica.com/products/ultrafast_fiber_lasers/femtofiber_smart/femtosecond_erbium_fiber_laser_1560_nm_femtoferb)
 """
 from . import Laser
-from ..util import visa_timeout_context
+from ..util import pyvisa as visa_timeout_context
 
 _INST_PRIORITY = 6
 _INST_PARAMS = ['visa_address']

--- a/instrumental/drivers/lasers/femto_ferb.py
+++ b/instrumental/drivers/lasers/femto_ferb.py
@@ -8,7 +8,7 @@ other things make the usb connection appear as a serial port, must be
 installed (available from http://www.toptica.com/products/ultrafast_fiber_lasers/femtofiber_smart/femtosecond_erbium_fiber_laser_1560_nm_femtoferb)
 """
 from . import Laser
-from ..util import pyvisa as visa_timeout_context
+from ..util import pyvisa_timeout_context
 
 _INST_PRIORITY = 6
 _INST_PARAMS = ['visa_address']

--- a/instrumental/drivers/lasers/santec.py
+++ b/instrumental/drivers/lasers/santec.py
@@ -1,0 +1,815 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013-2019 Nate Bogdanowicz
+"""
+Driver module for Santec Lasers.
+"""
+import datetime as dt
+import time
+import pyvisa
+from pyvisa.constants import InterfaceType
+import numpy as np
+from pint import UndefinedUnitError
+from enum import Enum
+
+from . import Laser
+from .. import VisaMixin, SCPI_Facet, Facet
+from ..util import visa_context, check_enums, as_enum
+from ...util import to_str
+from ...errors import Error
+from ... import u, Q_
+
+class IsEnabled(Enum):
+    Disabled = "0"
+    Enabled = "1"
+
+class WavelengthUnit(Enum):
+    nm = "0"
+    THz = "1"
+
+class PowerUnit(Enum):
+    dBm = "0"
+    mW = "1"
+
+class SweepMode(Enum):
+    StepOneWay = "0"
+    ContinuousOneWay = "1"
+    StepTwoWay = "2"
+    ContinuousTwoWay = "3"
+
+class SweepSpeed(Enum):
+    x1_nm_per_sec = "1"
+    x2_nm_per_sec = "2"
+    x5_nm_per_sec = "5"
+    x10_nm_per_sec = "10"
+    x20_nm_per_sec = "20"
+    x50_nm_per_sec = "50"
+    x100_nm_per_sec = "100"
+    x200_nm_per_sec = "200"
+
+class SweepState(Enum):
+    Stopped = "0"
+    Running = "1"
+    Standby = "3"
+    Preparation = "4"
+
+class AmplitudeModulationSource(Enum):
+    CoherenceControl = "0"
+    IntensityModulation = "1"
+    FrequencyModulation = "3"
+
+class TriggerActiveLevel(Enum):
+    High = "0"
+    Low = "1"
+
+class InputTriggerState(Enum):
+    Normal = "0"
+    Standby = "1"
+
+class OutputTriggerMode(Enum):
+    Unused = "0"  # "None" in the manual, can't use `None` as an Enum field in Python
+    Stop = "1"
+    Start = "2"
+    Step = "3"
+
+class TriggerStepMode(Enum):
+    Time = "0"
+    Wavelength = "1"
+
+class SantecMessageFormat(Enum):
+    Legacy = "0"
+    SCPI = "1"
+
+class MessageTermination(Enum):
+    CR = "0"
+    LF = "1"
+    CR_LF = "2"
+    Nothing = "3"
+
+tsl570_command_errors = {
+    0:      "No error",
+    -102:   "Syntax error",
+    -103:   "Invalid separator",
+    -108:   "Parameter not allowed",
+    -109:   "Missing parameter",
+    -113:   "Undefined header",
+    -148:   "Character data not allowed",
+    -200:   "Execution error",
+    -222:   "Data out of range",
+    -410:   "Query INTERRUPTED",
+}
+
+### Santec TSL-570 System Alerts (manual page 100, sec. 7.4.6) ###
+
+tsl570_system_alerts = {
+    0:          "Power supply Error1",
+    2:          "Power supply Error2",
+    3:          "Power supply Error3",
+    5:          "Wavelength Error",
+    6:          "Power setting Error",
+    7:          "Inter lock detection",
+    20:         "Temperature control Error1",
+    21:         "Temperature control Error2",
+    22:         "Temperature control Error3",
+    23:         "Ongoing Warm up",
+    25:         "Shutter Error",
+    26:         "Sensor Error",
+    27:         "Connection Error",
+    28:         "Exhaust Fan Error",
+}
+
+class TSL570(Laser, VisaMixin):
+    """
+    A class for Santec TSL-570 tunable laser.
+    """
+
+    _INST_PARAMS_ = ['visa_address']
+    _INST_VISA_INFO_ = ("SANTEC",["TSL-570"])
+
+    def _initialize(self):
+        self.resource.write_termination    =   "\r"
+        self.resource.read_termination     =   "\r"
+        idn_resp = self.query("*IDN?")
+        manufacturer, model, serial_number, firmware_version = idn_resp.split(",")
+        self.manufacturer = manufacturer
+        self.model = model
+        self.serial_number = serial_number
+        self.firmware_version = firmware_version
+    
+    #     if self.interface_type == InterfaceType.asrl:
+    #         terminator = self.query('RS232:trans:term?').strip()
+    #         self.resource.read_termination = terminator.replace('CR', '\r').replace('LF', '\n')
+    #     elif self.interface_type == InterfaceType.usb:
+    #         msg = self.query('*IDN?')
+    #         self.resource.read_termination = infer_termination(msg)
+    #     elif self.interface_type == InterfaceType.tcpip:
+    #         msg = self.query('*IDN?')
+    #         self.resource.write_termination    =   "\r"
+    #         self.resource.read_termination     =   "\r"
+    #     else:
+    #         pass
+
+        ### Set the TSL-570 communication format to Santec's "Legacy" style
+        # self.write('SYST:COMM:COD 0') 
+        self.communication_format = SantecMessageFormat.Legacy
+
+    ### Santec TSL-570 Facets ###
+
+    output_wavelength = SCPI_Facet(
+        "WAVelength",
+        type=        float,
+        units=        "nm",
+        doc=  "Sets the output wavelength. (manual page 69)",
+        readonly=    False,
+    ) 
+    wavelength_units = SCPI_Facet(
+        "WAVelength:UNIT",
+        type=         WavelengthUnit,
+        value=       {i: i.value for i in WavelengthUnit},
+        doc=  "Sets units of displayed wavelength. (manual page 70)",
+        readonly=    False,
+    )  
+    wavelength_fine_tuning = SCPI_Facet(
+        "WAVelength:FINe",
+        type=         float,
+        limits=       [-100.0,100.0,0.01],
+        doc=  "Sets Fine-Tuning value. (manual page 70)",
+        readonly=    False,
+    )    
+    optical_frequency = SCPI_Facet(
+        "FREQuency",
+        type=         float,
+        units=        "THz",
+        doc=  "Sets the output optical frequency. (manual page 71)",
+        readonly=    False,
+    )  
+    coherence_control = SCPI_Facet(
+        "COHCtrl",
+        type=         IsEnabled,
+        value=       {i: i.value for i in IsEnabled},
+        doc=  "Sets Coherence control status. (manual page 72)",
+        readonly=    False,
+    )  
+    output_on = SCPI_Facet(
+        "POWer:STATe",
+        type=         IsEnabled,
+        value=       {i: i.value for i in IsEnabled},
+        doc=  "Sets optical output status. (manual page 72)",
+        readonly=    False,
+    )  
+    output_attenuation = SCPI_Facet(
+        "POWer:ATTenuation",
+        type=         float,
+        units=        "decibel",
+        limits=       [0.0,30.0,0.01],
+        doc=  "Sets the attenuator value. (manual page 73)",
+        readonly=    False,
+    )  
+    auto_attenuation = SCPI_Facet(
+        "POWer:ATTenuation:AUTo",
+        type=         IsEnabled,
+        value=       {i: i.value for i in IsEnabled},
+        doc=  "Sets the power control mode. (manual page 73)",
+        readonly=    False,
+    )  
+    power_setpoint = SCPI_Facet(
+        "POWer",
+        type=         float,
+        units=        "dBm", # "self.power_unit",
+        limits=       [-15.0,20.0,0.01],
+        doc=  "Sets optical output power level set point. (manual page 74)",
+        readonly=    False,
+    )
+    power_measured = SCPI_Facet(
+        "POWer:actual",
+        type=         float,
+        units=        "dBm", # "self.power_unit",
+        doc=  "Measured optical output power level. (manual page 74)",
+        readonly=    True,
+    )  
+    shutter = SCPI_Facet(
+        "POWer:SHUTter",
+        type=         IsEnabled,
+        value=       {i: i.value for i in IsEnabled},
+        doc=  "Sets Open/Close status of the internal shutter. (manual page 75)",
+        readonly=    False,
+    )  
+    power_unit = SCPI_Facet(
+        "POWer:UNIT",
+        type =       PowerUnit,
+        value=       {PowerUnit.dBm:"0", PowerUnit.mW:"1"},
+        doc=  "Changes the unit of the power setting and display. (manual page 76)",
+        readonly=    False,
+    )  
+    sweep_start_wavelength = SCPI_Facet(
+        "WAVelength:SWEep:STARt",
+        type=         float,
+        units=        "nm",
+        doc=  "Sets the sweep start wavelength. (manual page 76)",
+        readonly=    False,
+    )  
+    sweep_start_frequency = SCPI_Facet(
+        "FREQuency:SWEep:STARt",
+        type=         float,
+        units=        "THz",
+        doc=  "Sets the sweep start wavelength in optical frequency. (manual page 77)",
+        readonly=    False,
+    )  
+    sweep_stop_wavelength = SCPI_Facet(
+        "WAVelength:SWEep:STOP",
+        type=         float,
+        units=        "nm",
+        doc=  "Sets the sweep stop wavelength. (manual page 78)",
+        readonly=    False,
+    )  
+    sweep_stop_frequency = SCPI_Facet(
+        "FREQuency:SWEep:STOP",
+        type=         float,
+        units=        "THz",
+        doc=  "Sets the sweep stop wavelength in optical frequency. (manual page 79)",
+        readonly=    False,
+    )  
+    sweep_mode = SCPI_Facet(
+        "wavelength:sweep:mode",
+        type=         SweepMode,
+        value=       {i: i.value for i in SweepMode},
+        doc=  "Sets the sweep mode. (manual page 80)",
+        readonly=    False,
+    )  
+    sweep_speed = SCPI_Facet(
+        "WAVelength:SWEep:SPEed",
+        # units=        "nm/s",
+        # value=        {1,2,5,10,20,50,100,200},
+        type=        SweepSpeed,
+        value=       {i: i.value for i in SweepSpeed},
+        doc=  "Sets the sweep speed. (manual page 81)",
+        readonly=    False,
+    )  
+    sweep_step_wavelength = SCPI_Facet(
+        "WAVelength:SWEep:STEP",
+        type=         float,
+        units=        "nm",
+        limits=       [0.0001,60.0,0.0001],
+        doc=  "Sets the step for Step sweep mode. (manual page 81)",
+        readonly=    False,
+    )  
+    sweep_step_frequency = SCPI_Facet(
+        "FREQuency:SWEep:STEP",
+        type=         float,
+        units=        "THz",
+        limits=       [0.00002,10.0,0.00001],
+        doc=  "Sets the step for Step sweep mode in optical frequency. (manual page 82)",
+        readonly=    False,
+    )  
+    sweep_dwell_time = SCPI_Facet(
+        "WAVelength:SWEep:DWELl",
+        type=         float,
+        units=        "s",
+        limits=       [0.0,999.9,0.1],
+        doc=  "Sets wait time between consequent steps in step sweep mode. (manual page 83)",
+        readonly=    False,
+    )  
+    sweep_num_cycles = SCPI_Facet(
+        "WAVelength:SWEep:CYCLes",
+        type=         int,
+        limits=       [0,999,1],
+        doc=  "Sets the sweep repetition times. (manual page 84)",
+        readonly=    False,
+    )
+    sweep_cycle_count = SCPI_Facet(
+        "WAVelength:SWEep:count",
+        type=         int,
+        limits=       [0,999,1],
+        doc=  "Gets the number of times the sweep has been repeated so far. (manual page 84)",
+        readonly=    True,
+    )  
+    sweep_delay_time = SCPI_Facet(
+        "WAVelength:SWEep:DELay",
+        type=         float,
+        units=        "s",
+        limits=       [0.0,999.9,0.1],
+        doc=  "Sets the wait time between consequent scans. (manual page 85)",
+        readonly=    False,
+    )  
+    sweep_state = SCPI_Facet(
+        "WAVelength:SWEep:STATe",
+        type=         SweepState,
+        value=       {i: i.value for i in SweepState},
+        doc=  "Sets sweep status and can be used to start a single sweep. (manual page 85)",
+        readonly=    True,
+    )  
+    amplitude_modulation_enabled = SCPI_Facet(
+        "AM:STATe",
+        type=         IsEnabled,
+        value=       {i: i.value for i in IsEnabled},
+        doc=  "Enables and disables modulation function of the laser output. (manual page 87)",
+        readonly=    False,
+    )  
+    amplitude_modulation_source = SCPI_Facet(
+        "AM:SOURce",
+        type=         AmplitudeModulationSource,
+        value=       {i: i.value for i in AmplitudeModulationSource},
+        doc=  "Sets modulation source. (manual page 88)",
+        readonly=    False,
+    )  
+    wavelength_offset = SCPI_Facet(
+        "WAVelength:OFFSet",
+        type=         float,
+        units=        "nm",
+        limits=       [-0.1,0.1,0.0001],
+        doc=  "Add the constant offset to the output wavelength. (manual page 88)",
+        readonly=    False,
+    )  
+    input_trigger_enable = SCPI_Facet(
+        "TRIGger:INPut:EXTernal",
+        type=         IsEnabled,
+        value=       {i: i.value for i in IsEnabled},
+        doc=  "Enables / Disables external trigger input. (manual page 89)",
+        readonly=    False,
+    )  
+    input_trigger_level = SCPI_Facet(
+        "TRIGger:INPut:EXTernal:ACTive",
+        type=         TriggerActiveLevel,
+        value=       {i: i.value for i in TriggerActiveLevel},
+        doc=  "Sets input trigger polarity. (manual page 90)",
+        readonly=    False,
+    )  
+    input_trigger_passthrough = SCPI_Facet(
+        "TRIGger:THRough",
+        type=        IsEnabled,
+        value=       {i: i.value for i in IsEnabled},
+        doc=  "Sets the trigger through mode. When True/On, input trigger signal is passed through to trigger output (manual page 93)",
+        readonly=    False,
+    ) 
+    input_trigger_state = SCPI_Facet(
+        "TRIGger:INPut:STANdby",
+        type=        InputTriggerState,
+        value=       {i: i.value for i in InputTriggerState},
+        doc=  "Sets the device in trigger signal input standby mode. (manual page 90)",
+        readonly=    False,
+    ) 
+    output_trigger_mode = SCPI_Facet(
+        "TRIGger:OUTPut",
+        type=        OutputTriggerMode,
+        value=       {i: i.value for i in OutputTriggerMode},
+        doc=  "Sets the timing of the trigger signal output. (manual page 91)",
+        readonly=    False,
+    )  
+    output_trigger_level = SCPI_Facet(
+        "TRIGger:OUTPut:ACTive",
+        type=        TriggerActiveLevel,
+        value=       {i: i.value for i in TriggerActiveLevel},
+        doc=  "Sets output trigger active level (high or low). (manual page 91)",
+        readonly=    False,
+    )  
+    output_trigger_step = SCPI_Facet(
+        "TRIGger:OUTPut:STEP",
+        type=         float,
+        units=        "nm",
+        limits=       [0.0001,60.0,0.0001],
+        doc=  "Sets the interval of the trigger signal output. (manual page 92)",
+        readonly=    False,
+    )  
+    output_trigger_step_type = SCPI_Facet(
+        "TRIGger:OUTPut:SETTing",
+        type=        TriggerStepMode,
+        value=       {i: i.value for i in TriggerStepMode},
+        doc=  "Sets the output trigger period mode. (manual page 93)",
+        readonly=    False,
+    )   
+    system_error = SCPI_Facet(
+        "SYSTem:error",
+        type=        str,
+        doc=  "Reads most recent system error. (manual page 94)",
+        readonly=    True,
+    )
+    gpib_address = SCPI_Facet(
+        "SYSTem:COMMunicate:GPIB:ADDRess",
+        type=        int,
+        limits=      [1,30,1],
+        doc=  "Sets the GPIB address. (manual page 94)",
+        readonly=    False,
+    )  
+    gpib_delimiter = SCPI_Facet(
+        "SYSTem:COMMunicate:GPIB:DELimiter",
+        # type=        int,
+        value=       {"\r":"0", "\n":"1", "\r\n":"2", "":"3",},
+        doc=  "Sets the command delimiter for GPIB communication. (manual page 95)",
+        readonly=    False,
+    )  
+    mac_address = SCPI_Facet(
+        "SYSTem:COMMunicate:ETHernet:macaddress",
+        type=         str,
+        doc=  "Reads out the MAC address of the laser's ethernet port. (manual page 95)",
+        readonly=    True,
+    )  
+    ip_address = SCPI_Facet(
+        "SYSTem:COMMunicate:ETHernet:IPADdress",
+        type=         str,
+        doc=  "Sets the laser's IP address in IPv4 format. (manual page 95)",
+        readonly=    False,
+    )  
+    ip_subnet_mask = SCPI_Facet(
+        "SYSTem:COMMunicate:ETHernet:SMASk",
+        type=         str,
+        doc=  "Sets the subnet mask in IPv4 format. (manual page 96)",
+        readonly=    False,
+    )  
+    ip_default_gateway = SCPI_Facet(
+        "SYSTem:COMMunicate:ETHernet:DGATeway",
+        type=         str,
+        doc=  "Sets the default gateway in IPv4 format. (manual page 96)",
+        readonly=    False,
+    )  
+    ip_port = SCPI_Facet(
+        "SYSTem:COMMunicate:ETHernet:PORT",
+        type=         int,
+        limits=       [0,65535,1],
+        doc=  "Sets the port number used for TCP/IP communication via the laser's ethernet port. (manual page 97)",
+        readonly=    False,
+    )  
+    communication_format = SCPI_Facet(
+        "SYSTem:COMMunicate:CODe",
+        # # type=         int,
+        # value=       {"Legacy":"0", "SCPI":"1",},
+        type=        SantecMessageFormat,
+        value=       {i: i.value for i in SantecMessageFormat},
+        doc=  "Sets the command set. (manual page 97)",
+        readonly=    False,
+    )
+    external_interlock = SCPI_Facet(
+        "system:lock",
+        type=        IsEnabled,
+        value=       {i: i.value for i in IsEnabled},
+        doc=  "Reads out the status of the laser's external interlock. (manual page 98)",
+        readonly=    True,
+    )    
+    display_brightness = SCPI_Facet(
+        "DISPlay:BRIGhtness",
+        type=         int,
+        limits=       [0,100,1],
+        doc=  "Sets brightness of the display (in %). (manual page 98)",
+        readonly=    False,
+    )
+    system_alert = SCPI_Facet(
+        "SYSTem:alert",
+        type=        str,
+        doc=  "Reads most recent system alert. (manual page 99)",
+        readonly=    True,
+    )
+    num_log_points = SCPI_Facet(
+        "READOUT:POINTS",
+        type=        int,
+        doc=  "Checks how many log data points are available to be read out. (manual page 86)",
+        readonly=    True,
+    )
+
+    ### TSL-570 Commands
+
+    def disable_wavelength_fine_tuning(self):
+        """Terminate Fine-Tuning operation. (manual page 71)"""
+        self.write("WAVelength:FINetuning:DISable")
+
+    def start_repeating_sweep(self):
+        """Start repeat wavelength sweep. (manual page 86)"""
+        self.write("WAVelength:SWEep:STATe:REPeat")
+    
+    def software_trigger(self):
+        """Execute sweep from trigger standby mode. (manual page 91)"""
+        self.write("TRIGger:INPut:SOFTtrigger")
+    
+    def shutdown(self):
+        """Shutdown TSL-570 laser. (manual page 98)"""
+        self.write("SPECial:SHUTdown")
+
+    def reboot(self):
+        """Reboot TSL-570 laser. (manual page 98)"""
+        self.write("SPECial:reboot")
+
+    def _read_data(
+            self,
+            query_string='READOUT:DATA?',
+            # bytes_per_sample=8, # 64-bit format
+            # dtype='float64',
+            bytes_per_sample=4, # 32-bit format
+            dtype='int32',
+    ):
+
+        with self.resource.ignore_warning(pyvisa.constants.VI_SUCCESS_MAX_CNT),\
+            visa_context(self.resource, timeout=10000, read_termination=None,
+                         end_input=pyvisa.constants.SerialTermination.none):
+
+            self.write(query_string)
+            visalib = self.resource.visalib
+            session = self.resource.session
+
+            # NB: Must take slice of bytes returned by visalib.read,
+            # to keep from autoconverting to int
+            width_byte = visalib.read(session, 2)[0][1:]  # read first 2 bytes
+            num_bytes = int(visalib.read(session, int(width_byte))[0])
+            buf = bytearray(num_bytes)
+            cursor = 0
+
+            while cursor < num_bytes:
+                raw_bin, _ = visalib.read(session, num_bytes-cursor)
+                buf[cursor:cursor+len(raw_bin)] = raw_bin
+                cursor += len(raw_bin)
+
+        # self.resource.read()  # Eat termination
+
+        num_points = int(num_bytes // bytes_per_sample)
+        # dtype = '>i{:d}'.format(bytes_per_sample)
+        log_data = np.frombuffer(buf, dtype=dtype, count=num_points)
+        return log_data
+
+    def read_wavelength_data(self,bytes_per_sample=4,dtype='int32',data_step=0.1*u.pm):
+        wavelength_data_raw = self._read_data(
+                query_string='READOUT:DATA?',
+                bytes_per_sample=bytes_per_sample,
+                dtype=dtype,
+        )
+        wavelength_data = (wavelength_data_raw*data_step).to('nm')
+        return wavelength_data
+
+    def read_power_data(self,bytes_per_sample=4,dtype='float32',data_step=Q_(1.0,"dBm")):
+        power_data_raw = self._read_data(
+                query_string='READOUT:DATA:POWER?',
+                bytes_per_sample=bytes_per_sample,
+                dtype=dtype,
+        )
+        # power_data = (power_data_raw*data_step).to('dBm')
+        power_data = power_data_raw*data_step
+        return power_data
+
+    def configure_continuous_sweep(
+        self,
+        sweep_start,
+        sweep_stop,
+        sweep_speed:SweepSpeed = SweepSpeed.x10_nm_per_sec,
+        sweep_mode:SweepMode = SweepMode.ContinuousOneWay,
+        sweep_dwell_time = 0.0 * u.second,
+        sweep_num_cycles = 1,
+        sweep_delay_time = 0.0 * u.second,
+        input_trigger_enable = IsEnabled.Enabled,
+        input_trigger_level = TriggerActiveLevel.High,
+        # input_trigger_state = InputTriggerState.Normal,
+        output_trigger_mode = OutputTriggerMode.Step,
+        output_trigger_level = TriggerActiveLevel.High,
+        output_trigger_step = 10 * u.pm,
+        output_trigger_step_type = TriggerStepMode.Time,
+        sleep_time=0.01*u.second,
+    ):
+        # Normalize units of start and stop wavelengths/frequencies, accepting either type of data
+        self.sweep_start_wavelength      =   sweep_start.to(u.nm,"sp")
+        self.sweep_stop_wavelength       =   sweep_stop.to(u.nm,"sp")
+
+        # Assign Facet values
+        self.sweep_speed                 =   sweep_speed
+        self.sweep_mode                  =   sweep_mode
+        self.sweep_dwell_time            =   sweep_dwell_time
+        self.sweep_num_cycles            =   sweep_num_cycles
+        self.sweep_delay_time            =   sweep_delay_time
+        self.input_trigger_enable        =   input_trigger_enable
+        self.input_trigger_level         =   input_trigger_level
+        # self.input_trigger_state         =   input_trigger_state
+        self.output_trigger_mode         =   output_trigger_mode
+        self.output_trigger_level        =   output_trigger_level
+        self.output_trigger_step         =   output_trigger_step
+        self.output_trigger_step_type    =   output_trigger_step_type
+        
+        # while self.sweep_cycle_count < self.sweep_num_cycles:
+
+    def wait_until_operation_complete(self,sleep_time=0.01*u.second):
+        opc = 0
+        while opc  == 0:
+            time.sleep(sleep_time.m_as(u.second))
+            opc = self.query('*OPC?')
+
+    def arm_input_trigger(self,sleep_time=0.01*u.second):
+        self.input_trigger_state = InputTriggerState.Standby
+        trigger_armed = False
+        while not(trigger_armed):
+            time.sleep(sleep_time.m_as(u.second))
+            if self.input_trigger_state is InputTriggerState.Standby:
+                trigger_armed = True
+
+    def start_sweep(self,sleep_time=0.01*u.second):
+        if self.output_wavelength != self.sweep_start_wavelength:
+            self.output_wavelength = self.sweep_start_wavelength
+        self.wait_until_operation_complete(sleep_time=sleep_time)
+        # if self.input_trigger_enable:
+        #     self.arm_input_trigger(sleep_time=sleep_time)
+        if self.input_trigger_enable:
+            self.arm_input_trigger(sleep_time=sleep_time)
+            self.write("WAVelength:SWEep:STATe 1")
+        else:
+            self.arm_input_trigger(sleep_time=sleep_time)
+            self.write("WAVelength:SWEep:STATe 1")
+            self.software_trigger()
+        
+    def run_sweep(self,sleep_time=0.01*u.second):
+        self.start_sweep(sleep_time=sleep_time)
+        while self.sweep_state in [SweepState.Preparation,SweepState.Running]:
+            time.sleep(sleep_time.m_as(u.second))
+        wavelength_data = self.read_wavelength_data()
+        power_data = self.read_power_data()
+        return wavelength_data, power_data
+
+
+    # def get_data(self, width=2, bounds=None):
+    #     """Retrieve wavelength, frequency or power values from the laser corresponding to trigger events or step values in the last sweep.
+
+    #     Pulls data from channel `channel` and returns it as a tuple ``(t,y)``
+    #     of unitful arrays.
+
+    #     Parameters
+    #     ----------
+    #     channel : int, optional
+    #         Channel number to pull trace from. Defaults to channel 1.
+    #     width : int, optional
+    #         Number of bytes per sample of data pulled from the scope. 1 or 2.
+    #     bounds : tuple of int, optional
+    #         (start, stop) tuple of first and last sample to read. Index starts at 1.
+
+    #     Returns
+    #     -------
+    #     t, y : pint.Quantity arrays
+    #         Unitful arrays of data from the scope. ``t`` is in seconds, while
+    #         ``y`` is in volts.
+    #     """
+    #     if width not in (1, 2):
+    #         raise ValueError('width must be 1 or 2')
+
+    #     with self.transaction():
+    #         self.write("data:source ch{}".format(channel))
+    #         self.write("data:width {}", width)
+    #         self.write("data:encdg RIBinary")
+
+    #     if bounds is None:
+    #         start = 1
+    #         # scope *should* truncate this to record length if it's too big
+    #         stop = getattr(self, 'max_waveform_length', 1000000)
+    #     else:
+    #         start, stop = bounds
+    #         wfm_len = self.waveform_length
+    #         if not (1 <= start <= stop <= wfm_len):
+    #             raise ValueError('bounds must satisfy 1 <= start <= stop <= {}'.format(wfm_len))
+
+    #     with self.transaction():
+    #         self.write("data:start {}".format(start))
+    #         self.write("data:stop {}".format(stop))
+
+    #     #self.resource.flow_control = 1  # Soft flagging (XON/XOFF flow control)
+    #     raw_data_y = self._read_curve(width=width)
+    #     raw_data_x = np.arange(1, len(raw_data_y)+1)
+
+    #     # Get scale and offset factors
+    #     wp = self._waveform_params()
+    #     x_units = self._tek_units(wp['xun'])
+    #     y_units = self._tek_units(wp['yun'])
+
+    #     data_x = Q_((raw_data_x - wp['pt_o'])*wp['xin'] + wp['xze'], x_units)
+    #     data_y = Q_((raw_data_y - wp['yof'])*wp['ymu'] + wp['yze'], y_units)
+
+    #     return data_x, data_y
+
+    # @staticmethod
+    # def _tek_units(unit_str):
+    #     unit_map = {
+    #         'U': '',
+    #         'Volts': 'V'
+    #     }
+
+    #     unit_str = unit_map.get(unit_str, unit_str)
+    #     try:
+    #         units = u.parse_units(unit_str)
+    #     except UndefinedUnitError:
+    #         units = u.dimensionless
+    #     return units
+
+    # def _read_curve(self, width):
+    #     with self.resource.ignore_warning(pyvisa.constants.VI_SUCCESS_MAX_CNT),\
+    #         visa_context(self.resource, timeout=10000, read_termination=None,
+    #                      end_input=pyvisa.constants.SerialTermination.none):
+
+    #         self.write("curve?")
+    #         visalib = self.resource.visalib
+    #         session = self.resource.session
+
+    #         # NB: Must take slice of bytes returned by visalib.read,
+    #         # to keep from autoconverting to int
+    #         width_byte = visalib.read(session, 2)[0][1:]  # read first 2 bytes
+    #         num_bytes = int(visalib.read(session, int(width_byte))[0])
+    #         buf = bytearray(num_bytes)
+    #         cursor = 0
+
+    #         while cursor < num_bytes:
+    #             raw_bin, _ = visalib.read(session, num_bytes-cursor)
+    #             buf[cursor:cursor+len(raw_bin)] = raw_bin
+    #             cursor += len(raw_bin)
+
+    #     self.resource.read()  # Eat termination
+
+    #     num_points = int(num_bytes // width)
+    #     dtype = '>i{:d}'.format(width)
+    #     return np.frombuffer(buf, dtype=dtype, count=num_points)
+
+    # def run_acquire(self):
+    #     """Sets the acquire state to 'run'"""
+    #     self.write("acquire:state run")
+
+    # def stop_acquire(self):
+    #     """Sets the acquire state to 'stop'"""
+    #     self.write("acquire:state stop")
+
+    # @property
+    # def interface_type(self):
+    #     return self.resource.interface_type
+
+    # @property
+    # def model(self):
+    #     _, model, _, _ = self.query('*IDN?').split(',', 3)
+    #     return model
+
+    # @property
+    # def channels(self):
+    #     try:
+    #         return MODEL_CHANNELS[self.model]
+    #     except KeyError:
+    #         raise KeyError('Unknown number of channels for this scope model')
+
+    # def read_events(self):
+    #     """Get a list of events from the Event Queue
+
+    #     Returns
+    #     -------
+    #     A list of (int, str) pairs containing the code and message for each event in the scope's
+    #     event queue.
+    #     """
+    #     events = []
+    #     while True:
+    #         event_info = self.query('evmsg?').split(',', 1)
+    #         code = int(event_info[0])
+    #         message = event_info[1][1:-1]
+    #         if code == 0:
+    #             break
+    #         elif code == 1:
+    #             self.query('*ESR?')  # Reload event queue
+    #         else:
+    #             events.append((code, message))
+    #     return events
+
+    # @property
+    # def _datetime(self):
+    #     resp = self.query(':date?;:time?')
+    #     return dt.datetime.strptime(resp, '"%Y-%m-%d";"%H:%M:%S"')
+
+    # @_datetime.setter
+    # def _datetime(self, value):
+    #     if not isinstance(value, dt.datetime):
+    #         raise TypeError('value must be a datetime object')
+    #     message = value.strftime(':date "%Y-%m-%d";:time "%H:%M:%S"')
+    #     self.write(message)
+
+    # horizontal_scale = SCPI_Facet('hor:main:scale', convert=float, units='s')
+    # horizontal_delay = SCPI_Facet('hor:delay:pos', convert=float, units='s')
+    # math_function = property(get_math_function, set_math_function)

--- a/instrumental/drivers/lockins/sr844.py
+++ b/instrumental/drivers/lockins/sr844.py
@@ -7,7 +7,7 @@ output to use.
 """
 from numpy import fromstring, float32
 from enum import Enum
-import visa
+import pyvisa as visa
 from ..util import check_units, check_enums
 from ...errors import InstrumentTypeError
 from ... import Q_

--- a/instrumental/drivers/lockins/sr844.py
+++ b/instrumental/drivers/lockins/sr844.py
@@ -7,7 +7,7 @@ output to use.
 """
 from numpy import fromstring, float32
 from enum import Enum
-import pyvisa as visa
+import pyvisa
 from ..util import check_units, check_enums
 from ...errors import InstrumentTypeError
 from ... import Q_
@@ -567,8 +567,8 @@ class SR844(Lockin):
             #Factor of 2 is so that the transfer completes before timing out
             self._rsrc.timeout = 2*BINARY_TIME_PER_POINT.to('ms').magnitude*points[1] + timeout
             self._rsrc.read_termination = None
-            self._rsrc.end_input = visa.constants.SerialTermination.none
-            with self._rsrc.ignore_warning(visa.constants.VI_SUCCESS_MAX_CNT):
+            self._rsrc.end_input = pyvisa.constants.SerialTermination.none
+            with self._rsrc.ignore_warning(pyvisa.constants.VI_SUCCESS_MAX_CNT):
                 raw_binary, _ = self._rsrc.visalib.read(self._rsrc.session,
                                                         points[1]*BYTES_PER_POINT)
             trace = fromstring(raw_binary, dtype=float32)

--- a/instrumental/drivers/lockins/sr850.py
+++ b/instrumental/drivers/lockins/sr850.py
@@ -8,7 +8,7 @@ output to use.
 """
 from numpy import fromstring, float32
 from enum import Enum
-import visa
+import pyvisa as visa
 from ..util import check_units, check_enums
 from ...errors import InstrumentTypeError
 from ... import Q_

--- a/instrumental/drivers/lockins/sr850.py
+++ b/instrumental/drivers/lockins/sr850.py
@@ -8,7 +8,7 @@ output to use.
 """
 from numpy import fromstring, float32
 from enum import Enum
-import pyvisa as visa
+import pyvisa
 from ..util import check_units, check_enums
 from ...errors import InstrumentTypeError
 from ... import Q_
@@ -842,8 +842,8 @@ class SR850:
             #Factor of 2 is so that the transfer completes before timing out
             self._rsrc.timeout = 2*BINARY_TIME_PER_POINT.to('ms').magnitude*points[1] + timeout
             self._rsrc.read_termination = None
-            self._rsrc.end_input = visa.constants.SerialTermination.none
-            with self._rsrc.ignore_warning(visa.constants.VI_SUCCESS_MAX_CNT):
+            self._rsrc.end_input = pyvisa.constants.SerialTermination.none
+            with self._rsrc.ignore_warning(pyvisa.constants.VI_SUCCESS_MAX_CNT):
                 raw_binary, _ = self._rsrc.visalib.read(self._rsrc.session,
                                                         points[1]*BYTES_PER_POINT)
             trace = fromstring(raw_binary, dtype=float32)

--- a/instrumental/drivers/motion/newmark.py
+++ b/instrumental/drivers/motion/newmark.py
@@ -9,7 +9,7 @@ from ...log import get_logger
 from .. import VisaMixin
 from ..util import check_units
 from ... import u
-import pyvisa as visa
+import pyvisa
 
 log = get_logger(__name__)
 
@@ -31,7 +31,7 @@ class NSCA1(Motion):
         self.serial = self._paramset['serial']
         # I only ever use channel 1, but maybe there are needs for more.
         self.channel = 1
-        self._rsrc = visa.ResourceManager().open_resource(
+        self._rsrc = pyvisa.ResourceManager().open_resource(
             self.serial,
             read_termination='\r',
             write_termination='\r')

--- a/instrumental/drivers/motion/newmark.py
+++ b/instrumental/drivers/motion/newmark.py
@@ -9,7 +9,7 @@ from ...log import get_logger
 from .. import VisaMixin
 from ..util import check_units
 from ... import u
-import visa
+import pyvisa as visa
 
 log = get_logger(__name__)
 

--- a/instrumental/drivers/powermeters/newport.py
+++ b/instrumental/drivers/powermeters/newport.py
@@ -20,7 +20,7 @@ import time
 
 from . import PowerMeter
 from .. import Facet, MessageFacet, VisaMixin, deprecated
-from ..util import pyvisa as visa_timeout_context
+from ..util import pyvisa_timeout_context
 from ... import Q_, u
 
 

--- a/instrumental/drivers/powermeters/newport.py
+++ b/instrumental/drivers/powermeters/newport.py
@@ -20,7 +20,7 @@ import time
 
 from . import PowerMeter
 from .. import Facet, MessageFacet, VisaMixin, deprecated
-from ..util import visa_timeout_context
+from ..util import pyvisa as visa_timeout_context
 from ... import Q_, u
 
 

--- a/instrumental/drivers/scopes/_tektronix_async.py
+++ b/instrumental/drivers/scopes/_tektronix_async.py
@@ -2,7 +2,7 @@
 # Copyright 2019 Nate Bogdanowicz
 from collections import defaultdict
 import numpy as np
-import visa
+import pyvisa as visa
 
 from ..util import visa_context
 from ... import Q_

--- a/instrumental/drivers/scopes/_tektronix_async.py
+++ b/instrumental/drivers/scopes/_tektronix_async.py
@@ -2,7 +2,7 @@
 # Copyright 2019 Nate Bogdanowicz
 from collections import defaultdict
 import numpy as np
-import pyvisa as visa
+import pyvisa
 
 from ..util import visa_context
 from ... import Q_
@@ -78,9 +78,9 @@ def async_get_data(self, channel=1, width=2):
 
 @method_of('TekScope')
 def _async_read_curve(self, width):
-    with self.resource.ignore_warning(visa.constants.VI_SUCCESS_MAX_CNT),\
+    with self.resource.ignore_warning(pyvisa.constants.VI_SUCCESS_MAX_CNT),\
         visa_context(self.resource, timeout=10000, read_termination=None,
-                     end_input=visa.constants.SerialTermination.none):
+                     end_input=pyvisa.constants.SerialTermination.none):
 
         self.write("curve?")
         async_read_chunk = self.resource._async_read_chunk

--- a/instrumental/drivers/scopes/agilent.py
+++ b/instrumental/drivers/scopes/agilent.py
@@ -6,7 +6,7 @@ Driver module for Tektronix oscilloscopes. Currently supports
 * TDS 3000 series
 * MSO/DPO 4000 series
 """
-import visa
+import pyvisa as visa
 from pyvisa.constants import InterfaceType
 import numpy as np
 from pint import UndefinedUnitError

--- a/instrumental/drivers/scopes/agilent.py
+++ b/instrumental/drivers/scopes/agilent.py
@@ -6,7 +6,7 @@ Driver module for Tektronix oscilloscopes. Currently supports
 * TDS 3000 series
 * MSO/DPO 4000 series
 """
-import pyvisa as visa
+import pyvisa
 from pyvisa.constants import InterfaceType
 import numpy as np
 from pint import UndefinedUnitError

--- a/instrumental/drivers/scopes/rigol.py
+++ b/instrumental/drivers/scopes/rigol.py
@@ -4,7 +4,7 @@ Driver module for Rigol oscilloscopes. Currently supports
 
 * DS1000Z series
 """
-import visa
+import pyvisa as visa
 from pyvisa.constants import InterfaceType
 import numpy as np
 from pint import UndefinedUnitError

--- a/instrumental/drivers/scopes/rigol.py
+++ b/instrumental/drivers/scopes/rigol.py
@@ -4,7 +4,7 @@ Driver module for Rigol oscilloscopes. Currently supports
 
 * DS1000Z series
 """
-import pyvisa as visa
+import pyvisa
 from pyvisa.constants import InterfaceType
 import numpy as np
 from pint import UndefinedUnitError

--- a/instrumental/drivers/scopes/tektronix.py
+++ b/instrumental/drivers/scopes/tektronix.py
@@ -5,7 +5,7 @@ Driver module for Tektronix oscilloscopes.
 """
 import datetime as dt
 
-import pyvisa as visa
+import pyvisa
 from pyvisa.constants import InterfaceType
 import numpy as np
 from pint import UndefinedUnitError
@@ -266,9 +266,9 @@ class TekScope(Scope, VisaMixin):
         return units
 
     def _read_curve(self, width):
-        with self.resource.ignore_warning(visa.constants.VI_SUCCESS_MAX_CNT),\
+        with self.resource.ignore_warning(pyvisa.constants.VI_SUCCESS_MAX_CNT),\
             visa_context(self.resource, timeout=10000, read_termination=None,
-                         end_input=visa.constants.SerialTermination.none):
+                         end_input=pyvisa.constants.SerialTermination.none):
 
             self.write("curve?")
             visalib = self.resource.visalib

--- a/instrumental/drivers/scopes/tektronix.py
+++ b/instrumental/drivers/scopes/tektronix.py
@@ -610,6 +610,7 @@ class MSO_DPO_4000(StatScope):
     _INST_VISA_INFO_ = ('TEKTRONIX', ['MSO4032', 'DPO4032', 'MSO4034', 'DPO4034',
                                       'MSO4054', 'DPO4054', 'MSO4104', 'DPO4104',
                                       'DPO4054B',])
+    max_waveform_length = 10_000_000
     datetime = TekScope._datetime
 
 class MSO_DPO_7000(StatScope):

--- a/instrumental/drivers/scopes/tektronix.py
+++ b/instrumental/drivers/scopes/tektronix.py
@@ -5,7 +5,7 @@ Driver module for Tektronix oscilloscopes.
 """
 import datetime as dt
 
-import visa
+import pyvisa as visa
 from pyvisa.constants import InterfaceType
 import numpy as np
 from pint import UndefinedUnitError

--- a/instrumental/drivers/spectrometers/agilent.py
+++ b/instrumental/drivers/spectrometers/agilent.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013-2015 Nate Bogdanowicz
+"""
+Driver module for HP 70000 spectrum analyzer.
+Based on Nate's Tektronix scope driver
+"""
+
+# import visa
+# import numpy as np
+# from instrumental import u, Q_
+# from pint import UndefinedUnitError
+# from instrumental.drivers.spectrometers import Spectrometer
+# from instrumental.drivers import _get_visa_instrument
+
+import pyvisa
+from pyvisa.constants import InterfaceType
+import numpy as np
+from pint import UndefinedUnitError
+from . import Spectrometer
+from .. import VisaMixin, SCPI_Facet
+#from ..util import visa_context
+from ... import u, Q_
+
+_INST_PARAMS_ = ['visa_address']
+_INST_VISA_INFO_ = {
+    'AgilentOSA': ('AGILENT', ['86142B'])
+}
+
+class AgilentOSA(Spectrometer, VisaMixin):
+    """
+    A base class for HP 70000 series spectrum analyzers
+    """
+    # def __init__(self,params=None):
+    #     """
+    #     Create a spectrometer object that has the given VISA name *name* and connect
+    #     to it. You can find available instrument names using the VISA
+    #     Instrument Manager.
+    #     """
+    #     if params:
+    #         self.inst = _instrument(params)
+    #     else:
+    #         self.inst = _instrument(default_params)
+    #     self.inst.read_termination = "\n"  # Needed for stripping termination
+    #     #self.inst.write("header OFF")
+    #     self.inst.write_termination = ';'
+    #     self.inst.write('TDF P') # set the trace data format to be decimal numbers in parameter units
+
+    _INST_PARAMS_ = ['visa_address']
+    _INST_VISA_INFO_ = ('AGILENT', ['86142B'])
+
+    def _initialize(self):
+        self._rsrc.read_termination = '\n'  # Needed for stripping termination
+        self._rsrc.timeout = 300
+        #self.inst.write("header OFF")
+        # self._rsrc.write_termination = ';'
+        self.write('FORMAT:DATA REAL32') # set the trace data format to be decimal numbers in parameter units
+        # if self.interface_type == InterfaceType.asrl:
+        #     terminator = self.query('RS232:trans:term?').strip()
+        #     self._rsrc.read_termination = terminator.replace('CR', '\r').replace('LF', '\n')
+        # elif self.interface_type == InterfaceType.usb:
+        #     terminator = self.query('RS232:trans:term?').strip()
+        #     self._rsrc.read_termination = terminator.replace('CR', '\r').replace('LF', '\n')
+        # elif self.interface_type == InterfaceType.tcpip:
+        #     pass
+        # else:
+        #     pass
+        #
+        # self.write("header OFF")
+
+    # def instrument_presets(self):
+    #     self.write('IP')
+    #     self.write('TDF P') # set the trace data format to be decimal numbers in parameter units
+
+    def set_center_wavelength(self,cf):
+        cf_nm = cf.to(u.nm).magnitude
+        self.write('SENSE:WAVELENGTH:CENTER {:4.5f}NM'.format(cf_nm))
+
+    def get_center_wavelength(self):
+        cf = (float(self.query('SENSE:WAVELENGTH:CENTER?').strip('+')) * u.m).to(u.nm)
+        return cf
+
+    def set_wavelength_span(self,sp):
+        sp_nm = sp.to(u.nm).magnitude
+        self.write('SENSE:WAVELENGTH:SPAN {:4.5f}NM'.format(sp_nm))
+
+    def get_wavelength_span(self):
+        sp = (float(self.query('SENSE:WAVELENGTH:SPAN?').strip('+')) * u.m).to(u.nm)
+        return sp
+
+    def set_resolution_bandwidth(self,rb):
+        rb_nm = rb.to(u.nm).magnitude
+        self.write('SENSE:BANDwidth:RESolution {:4.5f}NM'.format(rb_nm))
+
+    def get_resolution_bandwidth(self):
+        rb = (float(self.query('SENSE:BANDwidth:RESolution?').strip('+')) * u.m).to(u.nm)
+        return rb
+
+    def set_amplitude_units(self,au):
+        if au==u.watt:
+            self.write('UNIT:POWER W')
+        elif au==u.milliwatt:
+            self.write('UNIT:POWER MW')
+        elif au=='dBm':
+            self.write('UNIT:POWER DBM')
+
+    def get_amplitude_units(self):
+        au_str = self.query('UNIT:POWER?')
+        if au_str=='W':
+            au = u.watt
+        elif au_str=='MW':
+            au = u.milliwatt
+        elif au_str=='DBM':
+            au = u.dimensionless
+        return au
+
+    def set_sensitivity(self,sens):
+        #sens = 10*np.log10(sens.to(u.milliwatt).magnitude)
+        self.write('SENSe:POWer:AC:RANGe:LOW {:3.3E}'.format(sens.to(self.get_amplitude_units()).magnitude))
+
+    def set_log_scale(self,scale):
+        ### scale
+        # self.write('LG {}DB'.format(scale))
+        self.write("DISPlay:TRACe:Y:SCALe:SPACing LOGARITHMIC".format(scale))
+
+
+    def set_linear_scale(self):
+        self.write('LN')
+
+    def set_reference_level(self,ref_level):
+        ### scale
+        if self.get_amplitude_units()==u.dimensionless:
+            if ref_level.units==u.dimensionless:
+                self.write('RL {:3.3E} DBM'.format(ref_level.magnitude))
+            else:
+                self.write('RL {:3.3E} DBM'.format(10*np.log10(ref_level.to(u.milliwatt).magnitude)))
+        else:
+            if ref_level.units==u.dimensionless:
+                self.write('RL {:3.3E} mW'.format(10**(ref_level/10.0)))
+            else:
+                self.write('RL {:3.3E} mW'.format(ref_level.to(u.milliwatt).magnitude))
+
+    def get_sensitivity(self):
+        sens_dbm = float(self.query('SENSe:POWer:AC:RANGe:LOW?'))
+        sens = (10**(sens_dbm/10.0) * u.milliwatt).to(u.watt)
+        return sens
+
+    def get_spectrum(self,trace='A'):
+        self._rsrc.timeout = 10000
+        au = self.get_amplitude_units()
+        wl_center = self.get_center_wavelength()
+        wl_span = self.get_wavelength_span()
+        amp = np.fromstring(self.query(f'TRACE:DATA:Y? TR{trace}'),sep=',') * au
+        wl_start = wl_center - wl_span / 2.0
+        wl_stop = wl_center + wl_span / 2.0
+        n_pts = len(amp)
+        wl = Q_(np.linspace(wl_start.magnitude,wl_stop.magnitude,n_pts),wl_start.units)
+        self._rsrc.timeout = 300
+        return wl, amp
+
+
+
+    def get_data(self, channel=1):
+        """Retrieve a trace from the scope.
+
+        Pulls data from channel `channel` and returns it as a tuple ``(t,y)``
+        of unitful arrays.
+
+        Parameters
+        ----------
+        channel : int, optional
+            Channel number to pull trace from. Defaults to channel 1.
+
+        Returns
+        -------
+        t, y : pint.Quantity arrays
+            Unitful arrays of data from the scope. ``t`` is in seconds, while
+            ``y`` is in volts.
+        """
+        inst = self.inst
+
+        inst.write("data:source ch{}".format(channel))
+        stop = int(inst.query("wfmpre:nr_pt?"))  # Get source's number of points
+        stop = 10000
+        inst.write("data:width 2")
+        inst.write("data:encdg RIBinary")
+        inst.write("data:start 1")
+        inst.write("data:stop {}".format(stop))
+
+        #inst.flow_control = 1  # Soft flagging (XON/XOFF flow control)
+        tmo = inst.timeout
+        inst.timeout = 10000
+        inst.write("curve?")
+        inst.read_termination = None
+        inst.end_input = pyvisa.constants.SerialTermination.none
+        # TODO: Change this to be more efficient for huge datasets
+        with inst.ignore_warning(pyvisa.constants.VI_SUCCESS_MAX_CNT):
+            s = inst.visalib.read(inst.session, 2)  # read first 2 bytes
+            num_bytes = int(inst.visalib.read(inst.session, int(s[0][1]))[0])
+            buf = ''
+            while len(buf) < num_bytes:
+                raw_bin, _ = inst.visalib.read(inst.session, num_bytes-len(buf))
+                buf += raw_bin
+                print(len(raw_bin))
+        inst.end_input = pyvisa.constants.SerialTermination.termination_char
+        inst.read_termination = '\n'
+        inst.read()  # Eat termination
+        inst.timeout = tmo
+        raw_data_y = np.frombuffer(buf, dtype='>i2', count=int(num_bytes//2))
+
+        # Get scale and offset factors
+        x_scale = float(inst.query("wfmpre:xincr?"))
+        y_scale = float(inst.query("wfmpre:ymult?"))
+        x_zero = float(inst.query("wfmpre:xzero?"))
+        y_zero = float(inst.query("wfmpre:yzero?"))
+        x_offset = float(inst.query("wfmpre:pt_off?"))
+        y_offset = float(inst.query("wfmpre:yoff?"))
+
+        x_unit_str = inst.query("wfmpre:xunit?")[1:-1]
+        y_unit_str = inst.query("wfmpre:yunit?")[1:-1]
+
+        unit_map = {
+            'U': '',
+            'Volts': 'V'
+        }
+
+        x_unit_str = unit_map.get(x_unit_str, x_unit_str)
+        try:
+            x_unit = u.parse_units(x_unit_str)
+        except UndefinedUnitError:
+            x_unit = u.dimensionless
+
+        y_unit_str = unit_map.get(y_unit_str, y_unit_str)
+        try:
+            y_unit = u.parse_units(y_unit_str)
+        except UndefinedUnitError:
+            y_unit = u.dimensionless
+
+        raw_data_x = np.arange(1, stop+1)
+
+        data_x = Q_((raw_data_x - x_offset)*x_scale + x_zero, x_unit)
+        data_y = Q_((raw_data_y - y_offset)*y_scale + y_zero, y_unit)
+
+        return data_x, data_y
+
+    

--- a/instrumental/drivers/spectrometers/agilent.py
+++ b/instrumental/drivers/spectrometers/agilent.py
@@ -109,6 +109,8 @@ class AgilentOSA(Spectrometer, VisaMixin):
             au = u.watt
         elif au_str=='MW':
             au = u.milliwatt
+        elif au_str=='AUTO':
+            au = u.dimensionless
         elif au_str=='DBM':
             au = u.dimensionless
         return au

--- a/instrumental/drivers/spectrometers/ando.py
+++ b/instrumental/drivers/spectrometers/ando.py
@@ -1,0 +1,406 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013-2015 Nate Bogdanowicz
+"""
+Driver module for Yokogawa/Ando spectrum analyzers.
+Based on Nate's Tektronix scope driver
+"""
+
+# import visa
+# import numpy as np
+# from instrumental import u, Q_
+# from pint import UndefinedUnitError
+# from instrumental.drivers.spectrometers import Spectrometer
+# from instrumental.drivers import _get_visa_instrument
+
+import visa
+from pyvisa.constants import InterfaceType
+import numpy as np
+from time import sleep
+from pint import UndefinedUnitError
+from . import Spectrometer
+from .. import VisaMixin, SCPI_Facet
+#from ..util import visa_context
+from ... import u, Q_
+
+_INST_PARAMS = ['visa_address']
+_INST_VISA_INFO = {
+    'AQ6331': ('ANDO', ['AQ6331'])
+}
+# disp_visa_address = 'GPIB0::4::INSTR'
+# osa_visa_address = 'GPIB0::23::INSTR'
+# default_params = {'visa_address':osa_visa_address}
+
+# def _check_visa_support(visa_inst):
+#     id = visa_inst.query('ID?')
+#     if id=='HP70951B\n':
+#         return 'HPOSA'
+
+class AQ6331(Spectrometer, VisaMixin):
+    """
+    A base class for Ando/Yokogawa AQ6331 series spectrum analyzers
+    """
+    # def __init__(self,params=None):
+    #     """
+    #     Create a spectrometer object that has the given VISA name *name* and connect
+    #     to it. You can find available instrument names using the VISA
+    #     Instrument Manager.
+    #     """
+    #     if params:
+    #         self.inst = _instrument(params)
+    #     else:
+    #         self.inst = _instrument(default_params)
+    #     self.inst.read_termination = "\n"  # Needed for stripping termination
+    #     #self.inst.write("header OFF")
+    #     self.inst.write_termination = ';'
+    #     self.inst.write('TDF P') # set the trace data format to be decimal numbers in parameter units
+
+    def _initialize(self):
+        pass
+        # self.read_termination = "\n"  # Needed for stripping termination
+        # #self.inst.write("header OFF")
+        # self.write_termination = ';'
+        # self.write('TDF P') # set the trace data format to be decimal numbers in parameter units
+        # if self.interface_type == InterfaceType.asrl:
+        #     terminator = self.query('RS232:trans:term?').strip()
+        #     self._rsrc.read_termination = terminator.replace('CR', '\r').replace('LF', '\n')
+        # elif self.interface_type == InterfaceType.usb:
+        #     terminator = self.query('RS232:trans:term?').strip()
+        #     self._rsrc.read_termination = terminator.replace('CR', '\r').replace('LF', '\n')
+        # elif self.interface_type == InterfaceType.tcpip:
+        #     pass
+        # else:
+        #     pass
+        #
+        # self.write("header OFF")
+
+    # def instrument_presets(self):
+    #     self.write('IP')
+    #     self.write('TDF P') # set the trace data format to be decimal numbers in parameter units
+
+    def set_center_wavelength(self,cf):
+        cf_nm = cf.to(u.nm).magnitude
+        self.write('CTRWL{:4.2f}'.format(cf_nm))
+
+    def get_center_wavelength(self):
+        cf = np.float(self.query('CTRWL?')) * u.nm
+        return cf
+
+    def set_center_frequency(self,cf):
+        cf_THz = cf.to(u.THz).magnitude
+        self.write('CTRF{:4.2f}'.format(cf_THz))
+
+    def get_center_frequency(self):
+        cf = np.float(self.query('CTRF?')) * u.THz
+        return cf
+
+    def set_wavelength_span(self,sp):
+        sp_nm = sp.to(u.nm).magnitude
+        self.write('SPAN{:4.2f}'.format(sp_nm))
+
+    def get_wavelength_span(self):
+        sp = np.float(self.query('SPAN?')) * u.nm
+        return sp
+
+    def set_frequency_span(self,sp):
+        sp_THz = sp.to(u.THz).magnitude
+        self.write('SPANF{:4.2f}'.format(sp_THz))
+
+    def get_frequency_span(self):
+        sp = np.float(self.query('SPANF?')) * u.THz
+        return sp
+
+    def set_wavelength_resolution(self,rb):
+        rb_nm = rb.to(u.nm).magnitude
+        self.write('RESLN{:4.5f}'.format(rb_nm))
+
+    def get_wavelength_resolution(self):
+        rb = np.float(self.query('RESLN?')) * u.nm
+        return rb
+    def set_frequency_resolution(self,rb):
+        rb_GHz = rb.to(u.GHz).magnitude
+        self.write('RESLNF{:4.5f}'.format(rb_GHz))
+
+    def get_frequency_resolution(self):
+        rb = np.float(self.query('RESLNF?')) * u.GHz
+        return rb
+
+    def set_amplitude_units_PSD(self):
+        self.write('LSUNT1')
+
+    def set_amplitude_units_power(self):
+        self.write('LSUNT0')
+
+    def set_linear_yscale(self):
+        self.write('LSCLLIN')
+
+    def set_log_yscale(self,dB_per_division):
+        self.write('LSCL{:2.1f}'.format(dB_per_division))
+
+    def set_xscale_frequency(self):
+        self.write('XUNT1')
+
+    def set_xscale_wavelength(self):
+        self.write('XUNT0')
+
+    def get_xunit(self):
+        if int(self.query('XUNT?')):
+            return u.THz
+        else:
+            return u.nm
+
+    def get_amplitude_units(self):
+        psd = np.float(self.query('LSUNT?'))
+        scale = np.float(self.query('LSCL?'))
+        if psd:
+            if scale:
+                au = 1 / u.nm
+            else:
+                au = u.watt / u.nm
+        else:
+            if scale:
+                au = u.dimensioness
+            else:
+                au = u.watt
+        return au
+
+    def turn_LPF_on(self):
+        self.write('LPF1')
+
+    def turn_LPF_off(self):
+        self.write('LPF0')
+
+    def set_avg_number(self,avg_number):
+        self.write('AVG{:4.0f}'.format(avg_number))
+
+    def get_avg_number(self):
+        avg_number = np.float(self.query('AVG?'))
+        return avg_number
+
+    def set_number_points(self,n_pts):
+        self.write('SMPL{:4.0f}'.format(n_pts))
+
+    def get_number_points(self):
+        n_pts = np.int(self.query('SMPL?'))
+        return n_pts
+
+    def get_spectrum(self,trace='A'):
+        self.write('SD0') # sets string delimiter to ',' (1 would be CRLF)
+        sleep(0.1)
+        self.write('BD0') # sets block delimiter to CRLF (1 would be LF+EOI)
+        sleep(0.1)
+        self.write('HD0') # turns off 'header data'
+        sleep(0.1)
+        n_pts = self.get_number_points()
+        yu = self.get_amplitude_units()
+        amp = np.fromstring(self.query('LDAT'+trace),sep=',')[1:] * yu
+        wl = np.fromstring(self.query('WDAT'+trace),sep=',')[1:] * u.nm
+        return wl, amp
+
+
+
+    def get_data(self, channel=1):
+        """Retrieve a trace from the scope.
+
+        Pulls data from channel `channel` and returns it as a tuple ``(t,y)``
+        of unitful arrays.
+
+        Parameters
+        ----------
+        channel : int, optional
+            Channel number to pull trace from. Defaults to channel 1.
+
+        Returns
+        -------
+        t, y : pint.Quantity arrays
+            Unitful arrays of data from the scope. ``t`` is in seconds, while
+            ``y`` is in volts.
+        """
+        inst = self.inst
+
+        inst.write("data:source ch{}".format(channel))
+        stop = int(inst.query("wfmpre:nr_pt?"))  # Get source's number of points
+        stop = 10000
+        inst.write("data:width 2")
+        inst.write("data:encdg RIBinary")
+        inst.write("data:start 1")
+        inst.write("data:stop {}".format(stop))
+
+        #inst.flow_control = 1  # Soft flagging (XON/XOFF flow control)
+        tmo = inst.timeout
+        inst.timeout = 10000
+        inst.write("curve?")
+        inst.read_termination = None
+        inst.end_input = visa.constants.SerialTermination.none
+        # TODO: Change this to be more efficient for huge datasets
+        with inst.ignore_warning(visa.constants.VI_SUCCESS_MAX_CNT):
+            s = inst.visalib.read(inst.session, 2)  # read first 2 bytes
+            num_bytes = int(inst.visalib.read(inst.session, int(s[0][1]))[0])
+            buf = ''
+            while len(buf) < num_bytes:
+                raw_bin, _ = inst.visalib.read(inst.session, num_bytes-len(buf))
+                buf += raw_bin
+                print(len(raw_bin))
+        inst.end_input = visa.constants.SerialTermination.termination_char
+        inst.read_termination = '\n'
+        inst.read()  # Eat termination
+        inst.timeout = tmo
+        raw_data_y = np.frombuffer(buf, dtype='>i2', count=int(num_bytes//2))
+
+        # Get scale and offset factors
+        x_scale = float(inst.query("wfmpre:xincr?"))
+        y_scale = float(inst.query("wfmpre:ymult?"))
+        x_zero = float(inst.query("wfmpre:xzero?"))
+        y_zero = float(inst.query("wfmpre:yzero?"))
+        x_offset = float(inst.query("wfmpre:pt_off?"))
+        y_offset = float(inst.query("wfmpre:yoff?"))
+
+        x_unit_str = inst.query("wfmpre:xunit?")[1:-1]
+        y_unit_str = inst.query("wfmpre:yunit?")[1:-1]
+
+        unit_map = {
+            'U': '',
+            'Volts': 'V'
+        }
+
+        x_unit_str = unit_map.get(x_unit_str, x_unit_str)
+        try:
+            x_unit = u.parse_units(x_unit_str)
+        except UndefinedUnitError:
+            x_unit = u.dimensionless
+
+        y_unit_str = unit_map.get(y_unit_str, y_unit_str)
+        try:
+            y_unit = u.parse_units(y_unit_str)
+        except UndefinedUnitError:
+            y_unit = u.dimensionless
+
+        raw_data_x = np.arange(1, stop+1)
+
+        data_x = Q_((raw_data_x - x_offset)*x_scale + x_zero, x_unit)
+        data_y = Q_((raw_data_y - y_offset)*y_scale + y_zero, y_unit)
+
+        return data_x, data_y
+
+    def set_measurement_params(self, num, mtype, channel):
+        """Set the parameters for a measurement.
+
+        Parameters
+        ----------
+        num : int
+            Measurement number to set, from 1-4.
+        mtype : str
+            Type of the measurement, e.g. 'amplitude'
+        channel : int
+            Number of the channel to measure.
+        """
+        prefix = 'measurement:meas{}'.format(num)
+        self.inst.write("{}:type {};source ch{}".format(prefix, mtype,
+                                                        channel))
+
+    def read_measurement_stats(self, num):
+        """
+        Read the value and statistics of a measurement.
+
+        Parameters
+        ----------
+        num : int
+            Number of the measurement to read from, from 1-4
+
+        Returns
+        -------
+        stats : dict
+            Dictionary of measurement statistics. Includes value, mean, stddev,
+            minimum, maximum, and nsamps.
+        """
+        prefix = 'measurement:meas{}'.format(num)
+
+        if not self.are_measurement_stats_on():
+            raise Exception("Measurement statistics are turned off, "
+                            "please turn them on.")
+
+        # Potential issue: If we query for all of these values in one command,
+        # are they guaranteed to be taken from the same statistical set?
+        # Perhaps we should stop_acquire(), then run_acquire()...
+        keys = ['value', 'mean', 'stddev', 'minimum', 'maximum']
+        res = self.inst.query(prefix+':value?;mean?;stddev?;minimum?;maximum?;units?').split(';')
+        units = res.pop(-1).strip('"')
+        stats = {k: Q_(rval+units) for k, rval in zip(keys, res)}
+
+        num_samples = int(self.inst.query('measurement:statistics:weighting?'))
+        stats['nsamps'] = num_samples
+        return stats
+
+    def read_measurement_value(self, num):
+        """Read the value of a measurement.
+
+        Parameters
+        ----------
+        num : int
+            Number of the measurement to read from, from 1-4
+
+        Returns
+        -------
+        value : pint.Quantity
+            Value of the measurement
+        """
+        prefix = 'measurement:meas{}'.format(num)
+
+        raw_value, raw_units = self.inst.query('{}:value?;units?'.format(prefix)).split(';')
+        units = raw_units.strip('"')
+        return Q_(raw_value+units)
+
+    def set_math_function(self, expr):
+        """Set the expression used by the MATH channel.
+
+        Parameters
+        ----------
+        expr : str
+            a string representing the MATH expression, using channel variables
+            CH1, CH2, etc. eg. 'CH1/CH2+CH3'
+        """
+        self.inst.write("math:type advanced")
+        self.inst.write('math:define "{}"'.format(expr))
+
+    def get_math_function(self):
+        return self.inst.query("math:define?").strip('"')
+
+    def run_acquire(self):
+        """Sets the acquire state to 'run'"""
+        self.inst.write("acquire:state run")
+
+    def stop_acquire(self):
+        """Sets the acquire state to 'stop'"""
+        self.inst.write("acquire:state stop")
+
+    def are_measurement_stats_on(self):
+        """Returns whether measurement statistics are currently enabled"""
+        res = self.inst.query("measu:statistics:mode?")
+        return res not in ['OFF', '0']
+
+    def enable_measurement_stats(self, enable=True):
+        """Enables measurement statistics.
+
+        When enabled, measurement statistics are kept track of, including
+        'mean', 'stddev', 'minimum', 'maximum', and 'nsamps'.
+
+        Parameters
+        ----------
+        enable : bool
+            Whether measurement statistics should be enabled
+        """
+        # For some reason, the DPO 4034 uses ALL instead of ON
+        self.inst.write("measu:statistics:mode {}".format('ALL' if enable else 'OFF'))
+
+    def disable_measurement_stats(self):
+        """Disables measurement statistics"""
+        self.enable_measurement_stats(False)
+
+    def set_measurement_nsamps(self, nsamps):
+        """Sets the number of samples used to compute measurements.
+
+        Parameters
+        ----------
+        nsamps : int
+            Number of samples used to compute measurements
+        """
+        self.inst.write("measu:stati:weighting {}".format(nsamps))

--- a/instrumental/drivers/spectrometers/hp.py
+++ b/instrumental/drivers/spectrometers/hp.py
@@ -1,0 +1,370 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013-2015 Nate Bogdanowicz
+"""
+Driver module for HP 70000 spectrum analyzer.
+Based on Nate's Tektronix scope driver
+"""
+
+# import visa
+# import numpy as np
+# from instrumental import u, Q_
+# from pint import UndefinedUnitError
+# from instrumental.drivers.spectrometers import Spectrometer
+# from instrumental.drivers import _get_visa_instrument
+
+import pyvisa
+from pyvisa.constants import InterfaceType
+import numpy as np
+from pint import UndefinedUnitError
+from . import Spectrometer
+from .. import VisaMixin, SCPI_Facet
+#from ..util import visa_context
+from ... import u, Q_
+
+_INST_PARAMS = ['visa_address']
+_INST_VISA_INFO = {
+    'HPOSA': ('HEWLETT-PACKARD', ['70951B'])
+}
+# disp_visa_address = 'GPIB0::4::INSTR'
+# osa_visa_address = 'GPIB0::23::INSTR'
+# default_params = {'visa_address':osa_visa_address}
+
+def _check_visa_support(visa_inst):
+    id = visa_inst.query('ID?')
+    if id=='HP70951B\n':
+        return 'HPOSA'
+
+class HPOSA(Spectrometer, VisaMixin):
+    """
+    A base class for HP 70000 series spectrum analyzers
+    """
+    # def __init__(self,params=None):
+    #     """
+    #     Create a spectrometer object that has the given VISA name *name* and connect
+    #     to it. You can find available instrument names using the VISA
+    #     Instrument Manager.
+    #     """
+    #     if params:
+    #         self.inst = _instrument(params)
+    #     else:
+    #         self.inst = _instrument(default_params)
+    #     self.inst.read_termination = "\n"  # Needed for stripping termination
+    #     #self.inst.write("header OFF")
+    #     self.inst.write_termination = ';'
+    #     self.inst.write('TDF P') # set the trace data format to be decimal numbers in parameter units
+
+    def _initialize(self):
+        self._rsrc.read_termination = '\n'  # Needed for stripping termination
+        self._rsrc.timeout = 300
+        #self.inst.write("header OFF")
+        self._rsrc.write_termination = ';'
+        self.write('TDF P') # set the trace data format to be decimal numbers in parameter units
+        # if self.interface_type == InterfaceType.asrl:
+        #     terminator = self.query('RS232:trans:term?').strip()
+        #     self._rsrc.read_termination = terminator.replace('CR', '\r').replace('LF', '\n')
+        # elif self.interface_type == InterfaceType.usb:
+        #     terminator = self.query('RS232:trans:term?').strip()
+        #     self._rsrc.read_termination = terminator.replace('CR', '\r').replace('LF', '\n')
+        # elif self.interface_type == InterfaceType.tcpip:
+        #     pass
+        # else:
+        #     pass
+        #
+        # self.write("header OFF")
+
+    def instrument_presets(self):
+        self.write('IP')
+        self.write('TDF P') # set the trace data format to be decimal numbers in parameter units
+
+    def set_center_wavelength(self,cf):
+        cf_nm = cf.to(u.nm).magnitude
+        self.write('CF {:4.5f}NM'.format(cf_nm))
+
+    def get_center_wavelength(self):
+        cf = (np.float(self.query('CF?')) * u.m).to(u.nm)
+        return cf
+
+    def set_wavelength_span(self,sp):
+        sp_nm = sp.to(u.nm).magnitude
+        self.write('SP {:4.5f}NM'.format(sp_nm))
+
+    def get_wavelength_span(self):
+        sp = (np.float(self.query('SP?')) * u.m).to(u.nm)
+        return sp
+
+    def set_resolution_bandwidth(self,rb):
+        rb_nm = rb.to(u.nm).magnitude
+        self.write('RB {:4.5f}NM'.format(rb_nm))
+
+    def get_resolution_bandwidth(self):
+        rb = (np.float(self.query('RB?')) * u.m).to(u.nm)
+        return rb
+
+    def set_amplitude_units(self,au):
+        if au==u.watt:
+            self.write('AUNITS W')
+        elif au==u.milliwatt:
+            self.write('AUNITS MW')
+        elif au=='dBm':
+            self.write('AUNITS DBM')
+
+    def get_amplitude_units(self):
+        au_str = self.query('AUNITS?')
+        if au_str=='W':
+            au = u.watt
+        elif au_str=='MW':
+            au = u.milliwatt
+        elif au_str=='DBM':
+            au = u.dimensionless
+        return au
+
+    def set_sensitivity(self,sens):
+        #sens = 10*np.log10(sens.to(u.milliwatt).magnitude)
+        self.write('SENS {:3.3E}'.format(sens.to(self.get_amplitude_units()).magnitude))
+
+    def set_log_scale(self,scale):
+        ### scale
+        self.write('LG {}DB'.format(scale))
+
+    def set_linear_scale(self):
+        self.write('LN')
+
+    def set_reference_level(self,ref_level):
+        ### scale
+        if self.get_amplitude_units()==u.dimensionless:
+            if ref_level.units==u.dimensionless:
+                self.write('RL {:3.3E} DBM'.format(ref_level.magnitude))
+            else:
+                self.write('RL {:3.3E} DBM'.format(10*np.log10(ref_level.to(u.milliwatt).magnitude)))
+        else:
+            if ref_level.units==u.dimensionless:
+                self.write('RL {:3.3E} mW'.format(10**(ref_level/10.0)))
+            else:
+                self.write('RL {:3.3E} mW'.format(ref_level.to(u.milliwatt).magnitude))
+
+    def get_sensitivity(self):
+        sens_dbm = np.float(self.query('SENS?'))
+        sens = (10**(sens_dbm/10.0) * u.milliwatt).to(u.watt)
+        return sens
+
+    def get_spectrum(self,trace='A'):
+        self._rsrc.timeout = 10000
+        au = self.get_amplitude_units()
+        wl_center = self.get_center_wavelength()
+        wl_span = self.get_wavelength_span()
+        amp = np.fromstring(self.query('TR'+trace+'?'),sep=',') * au
+        wl_start = wl_center - wl_span / 2.0
+        wl_stop = wl_center + wl_span / 2.0
+        n_pts = len(amp)
+        wl = Q_(np.linspace(wl_start.magnitude,wl_stop.magnitude,n_pts),wl_start.units)
+        self._rsrc.timeout = 300
+        return wl, amp
+
+
+
+    def get_data(self, channel=1):
+        """Retrieve a trace from the scope.
+
+        Pulls data from channel `channel` and returns it as a tuple ``(t,y)``
+        of unitful arrays.
+
+        Parameters
+        ----------
+        channel : int, optional
+            Channel number to pull trace from. Defaults to channel 1.
+
+        Returns
+        -------
+        t, y : pint.Quantity arrays
+            Unitful arrays of data from the scope. ``t`` is in seconds, while
+            ``y`` is in volts.
+        """
+        inst = self.inst
+
+        inst.write("data:source ch{}".format(channel))
+        stop = int(inst.query("wfmpre:nr_pt?"))  # Get source's number of points
+        stop = 10000
+        inst.write("data:width 2")
+        inst.write("data:encdg RIBinary")
+        inst.write("data:start 1")
+        inst.write("data:stop {}".format(stop))
+
+        #inst.flow_control = 1  # Soft flagging (XON/XOFF flow control)
+        tmo = inst.timeout
+        inst.timeout = 10000
+        inst.write("curve?")
+        inst.read_termination = None
+        inst.end_input = pyvisa.constants.SerialTermination.none
+        # TODO: Change this to be more efficient for huge datasets
+        with inst.ignore_warning(pyvisa.constants.VI_SUCCESS_MAX_CNT):
+            s = inst.visalib.read(inst.session, 2)  # read first 2 bytes
+            num_bytes = int(inst.visalib.read(inst.session, int(s[0][1]))[0])
+            buf = ''
+            while len(buf) < num_bytes:
+                raw_bin, _ = inst.visalib.read(inst.session, num_bytes-len(buf))
+                buf += raw_bin
+                print(len(raw_bin))
+        inst.end_input = pyvisa.constants.SerialTermination.termination_char
+        inst.read_termination = '\n'
+        inst.read()  # Eat termination
+        inst.timeout = tmo
+        raw_data_y = np.frombuffer(buf, dtype='>i2', count=int(num_bytes//2))
+
+        # Get scale and offset factors
+        x_scale = float(inst.query("wfmpre:xincr?"))
+        y_scale = float(inst.query("wfmpre:ymult?"))
+        x_zero = float(inst.query("wfmpre:xzero?"))
+        y_zero = float(inst.query("wfmpre:yzero?"))
+        x_offset = float(inst.query("wfmpre:pt_off?"))
+        y_offset = float(inst.query("wfmpre:yoff?"))
+
+        x_unit_str = inst.query("wfmpre:xunit?")[1:-1]
+        y_unit_str = inst.query("wfmpre:yunit?")[1:-1]
+
+        unit_map = {
+            'U': '',
+            'Volts': 'V'
+        }
+
+        x_unit_str = unit_map.get(x_unit_str, x_unit_str)
+        try:
+            x_unit = u.parse_units(x_unit_str)
+        except UndefinedUnitError:
+            x_unit = u.dimensionless
+
+        y_unit_str = unit_map.get(y_unit_str, y_unit_str)
+        try:
+            y_unit = u.parse_units(y_unit_str)
+        except UndefinedUnitError:
+            y_unit = u.dimensionless
+
+        raw_data_x = np.arange(1, stop+1)
+
+        data_x = Q_((raw_data_x - x_offset)*x_scale + x_zero, x_unit)
+        data_y = Q_((raw_data_y - y_offset)*y_scale + y_zero, y_unit)
+
+        return data_x, data_y
+
+    def set_measurement_params(self, num, mtype, channel):
+        """Set the parameters for a measurement.
+
+        Parameters
+        ----------
+        num : int
+            Measurement number to set, from 1-4.
+        mtype : str
+            Type of the measurement, e.g. 'amplitude'
+        channel : int
+            Number of the channel to measure.
+        """
+        prefix = 'measurement:meas{}'.format(num)
+        self.inst.write("{}:type {};source ch{}".format(prefix, mtype,
+                                                        channel))
+
+    def read_measurement_stats(self, num):
+        """
+        Read the value and statistics of a measurement.
+
+        Parameters
+        ----------
+        num : int
+            Number of the measurement to read from, from 1-4
+
+        Returns
+        -------
+        stats : dict
+            Dictionary of measurement statistics. Includes value, mean, stddev,
+            minimum, maximum, and nsamps.
+        """
+        prefix = 'measurement:meas{}'.format(num)
+
+        if not self.are_measurement_stats_on():
+            raise Exception("Measurement statistics are turned off, "
+                            "please turn them on.")
+
+        # Potential issue: If we query for all of these values in one command,
+        # are they guaranteed to be taken from the same statistical set?
+        # Perhaps we should stop_acquire(), then run_acquire()...
+        keys = ['value', 'mean', 'stddev', 'minimum', 'maximum']
+        res = self.inst.query(prefix+':value?;mean?;stddev?;minimum?;maximum?;units?').split(';')
+        units = res.pop(-1).strip('"')
+        stats = {k: Q_(rval+units) for k, rval in zip(keys, res)}
+
+        num_samples = int(self.inst.query('measurement:statistics:weighting?'))
+        stats['nsamps'] = num_samples
+        return stats
+
+    def read_measurement_value(self, num):
+        """Read the value of a measurement.
+
+        Parameters
+        ----------
+        num : int
+            Number of the measurement to read from, from 1-4
+
+        Returns
+        -------
+        value : pint.Quantity
+            Value of the measurement
+        """
+        prefix = 'measurement:meas{}'.format(num)
+
+        raw_value, raw_units = self.inst.query('{}:value?;units?'.format(prefix)).split(';')
+        units = raw_units.strip('"')
+        return Q_(raw_value+units)
+
+    def set_math_function(self, expr):
+        """Set the expression used by the MATH channel.
+
+        Parameters
+        ----------
+        expr : str
+            a string representing the MATH expression, using channel variables
+            CH1, CH2, etc. eg. 'CH1/CH2+CH3'
+        """
+        self.inst.write("math:type advanced")
+        self.inst.write('math:define "{}"'.format(expr))
+
+    def get_math_function(self):
+        return self.inst.query("math:define?").strip('"')
+
+    def run_acquire(self):
+        """Sets the acquire state to 'run'"""
+        self.inst.write("acquire:state run")
+
+    def stop_acquire(self):
+        """Sets the acquire state to 'stop'"""
+        self.inst.write("acquire:state stop")
+
+    def are_measurement_stats_on(self):
+        """Returns whether measurement statistics are currently enabled"""
+        res = self.inst.query("measu:statistics:mode?")
+        return res not in ['OFF', '0']
+
+    def enable_measurement_stats(self, enable=True):
+        """Enables measurement statistics.
+
+        When enabled, measurement statistics are kept track of, including
+        'mean', 'stddev', 'minimum', 'maximum', and 'nsamps'.
+
+        Parameters
+        ----------
+        enable : bool
+            Whether measurement statistics should be enabled
+        """
+        # For some reason, the DPO 4034 uses ALL instead of ON
+        self.inst.write("measu:statistics:mode {}".format('ALL' if enable else 'OFF'))
+
+    def disable_measurement_stats(self):
+        """Disables measurement statistics"""
+        self.enable_measurement_stats(False)
+
+    def set_measurement_nsamps(self, nsamps):
+        """Sets the number of samples used to compute measurements.
+
+        Parameters
+        ----------
+        nsamps : int
+            Number of samples used to compute measurements
+        """
+        self.inst.write("measu:stati:weighting {}".format(nsamps))

--- a/instrumental/drivers/wavemeters/burleigh.py
+++ b/instrumental/drivers/wavemeters/burleigh.py
@@ -9,7 +9,7 @@ import warnings
 import time
 
 from . import Wavemeter
-from ..util import pyvisa as visa_timeout_context
+from ..util import pyvisa_timeout_context
 from ... import Q_
 
 # Constants; See Appendix A of WA-1000/1500 manual for details

--- a/instrumental/drivers/wavemeters/burleigh.py
+++ b/instrumental/drivers/wavemeters/burleigh.py
@@ -9,7 +9,7 @@ import warnings
 import time
 
 from . import Wavemeter
-from ..util import visa_timeout_context
+from ..util import pyvisa as visa_timeout_context
 from ... import Q_
 
 # Constants; See Appendix A of WA-1000/1500 manual for details


### PR DESCRIPTION
The goal of this pull request simply to replace all instances of `import visa` with `import pyvisa as visa`, which is required for use with the current PyVISA release. This change fixed my ability to identify visa instruments with instrumental. 

Let me know if any changes are needed. Thanks!