### PR TITLE
Update thorlabs_ccs.py visa -> pyvisa

### DIFF
--- a/instrumental/drivers/spectrometers/thorlabs_ccs.py
+++ b/instrumental/drivers/spectrometers/thorlabs_ccs.py
@@ -10,7 +10,7 @@ from enum import Enum
 from warnings import warn
 
 import numpy as np
-from visa import ResourceManager
+from pyvisa import ResourceManager
 from cffi import FFI
 from nicelib import NiceLib, Sig, NiceObject, load_lib, RetHandler, ret_ignore
 


### PR DESCRIPTION
I changed the import of the Resource manager from visa to pyvisa. I have tested that wit a CCS spectrometer with a Python 3.10 Anaconda environment.