### PR TITLE
fixes building for thorlabs kinesis devices

### DIFF
--- a/instrumental/drivers/motion/_kinesis/_build_kinesis.py
+++ b/instrumental/drivers/motion/_kinesis/_build_kinesis.py
@@ -3,6 +3,11 @@
 from nicelib import build_lib
 from nicelib.process import modify_pattern
 
+# add Kinesis Path to system path so that 'ctypes.util.find_library' can find the dll files
+import os
+os.environ['PATH'] = os.environ.get('PATH','')+';'+os.environ.get('ProgramFiles')+'\Thorlabs\Kinesis'
+os.environ['PATH'] = os.environ.get('PATH','')+';'+os.environ.get('ProgramFiles(x86)')+'\Thorlabs\Kinesis'
+
 # shared:
 #   TLI (top-level interface?)
 #   MOT (motors)


### PR DESCRIPTION
'ctypes.util.find_library' was not able to find the dll files so I added the path to the systempath