### PR TITLE
Remove "U" mode from from_file's open() for 3.12 compatability.

### DIFF
--- a/instrumental/conf.py
+++ b/instrumental/conf.py
@@ -29,7 +29,7 @@ save_dir = os.path.join(user_data_dir, 'instruments')
 
 def copy_file_text(from_path, to_path):
     """Copies a text file, using platform-specific line endings"""
-    with open(from_path, 'rU') as from_file:
+    with open(from_path, 'r') as from_file:
         with open(to_path, 'w') as to_file:
             to_file.writelines((line for line in from_file))
 


### PR DESCRIPTION
The `U` file mode tells Python to read the file in "universal newlines" mode. This has been the default as of Python 3.0 and should be controlled from the newline keyword parameter which deprecated the `U` mode specifier.

`U` was removed in Python 3.12 and now causes a `ValueError` if used.
